### PR TITLE
Makefileの-includeによるbugの修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@ DPS_DIRS		=	$(shell find  $(SRC_DIR) -type d | xargs -I{} echo $(DPS_DIR)/{})
 SRCS		=	$(shell find $(SRC_DIR) -type f -name "*.cpp")
 OBJS		=	$(addprefix $(OBJ_DIR)/,  $(SRCS:.cpp=.o))
 DPS			=	$(addprefix $(DPS_DIR)/,  $(SRCS:.cpp=.d))
--include $(DPS)
 
 .PHONY: all
 all: $(OBJ_DIRS) $(DPS_DIRS) $(NAME)
+
+-include $(DPS)
 
 $(NAME): $(OBJS)
 	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS)
@@ -51,3 +52,7 @@ test:
 .PHONY: run_test
 run_test: test
 	./tests/tests
+
+p:
+	echo $(OBJ_DIRS)
+	echo $(O)

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,3 @@ test:
 run_test: test
 	./tests/tests
 
-p:
-	echo $(OBJ_DIRS)
-	echo $(O)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,10 +14,11 @@ GTEST_LIB	=	gtest_main.a
 SRCS		=	$(shell find $(SRC_DIR) -type f -name "*.cpp")
 OBJS		=	$(addprefix $(OBJ_DIR)/,  $(SRCS:.cpp=.o))
 DPS			=	$(addprefix $(DPS_DIR)/,  $(SRCS:.cpp=.d))
--include $(DPS)
 
 .PHONY: all
 all: $(NAME)
+
+-include $(DPS)
 
 $(NAME): $(GOOGLE_TEST) $(GTEST_LIB) $(OBJ_DIRS) $(DPS_DIRS) $(OBJS)
 	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS) $(GTEST_LIB)


### PR DESCRIPTION
-includeで.dファイルの中身が展開されてmake とmake all が異なる場合があったのでなおしました。