### PR TITLE
`/src/utils` に道具系ファイルを追加

### DIFF
--- a/src/utils/CharFilter.cpp
+++ b/src/utils/CharFilter.cpp
@@ -1,7 +1,7 @@
 #include "CharFilter.hpp"
 #define ELEMS 32
 
-HTTP::CharFilter::CharFilter(const byte_string& chars) {
+HTTP::CharFilter::CharFilter(const byte_string &chars) {
     fill(chars);
 }
 
@@ -13,23 +13,23 @@ HTTP::CharFilter::CharFilter(byte_type from, byte_type to) {
     fill(from, to);
 }
 
-HTTP::CharFilter::CharFilter(const CharFilter& other) {
+HTTP::CharFilter::CharFilter(const CharFilter &other) {
     *this = other;
 }
 
-HTTP::CharFilter& HTTP::CharFilter::operator=(const CharFilter& rhs) {
+HTTP::CharFilter &HTTP::CharFilter::operator=(const CharFilter &rhs) {
     if (this != &rhs) {
         memcpy(filter, rhs.filter, ELEMS);
     }
     return *this;
 }
 
-HTTP::CharFilter& HTTP::CharFilter::operator=(const byte_string& rhs) {
+HTTP::CharFilter &HTTP::CharFilter::operator=(const byte_string &rhs) {
     fill(rhs);
     return *this;
 }
 
-HTTP::CharFilter HTTP::CharFilter::operator|(const CharFilter& rhs) const {
+HTTP::CharFilter HTTP::CharFilter::operator|(const CharFilter &rhs) const {
     CharFilter n(*this);
     for (int i = 0; i < ELEMS; ++i) {
         n.filter[i] |= rhs.filter[i];
@@ -37,7 +37,7 @@ HTTP::CharFilter HTTP::CharFilter::operator|(const CharFilter& rhs) const {
     return n;
 }
 
-HTTP::CharFilter HTTP::CharFilter::operator&(const CharFilter& rhs) const {
+HTTP::CharFilter HTTP::CharFilter::operator&(const CharFilter &rhs) const {
     CharFilter n(*this);
     for (int i = 0; i < ELEMS; ++i) {
         n.filter[i] &= rhs.filter[i];
@@ -45,7 +45,7 @@ HTTP::CharFilter HTTP::CharFilter::operator&(const CharFilter& rhs) const {
     return n;
 }
 
-HTTP::CharFilter HTTP::CharFilter::operator^(const CharFilter& rhs) const {
+HTTP::CharFilter HTTP::CharFilter::operator^(const CharFilter &rhs) const {
     CharFilter n(*this);
     for (int i = 0; i < ELEMS; ++i) {
         n.filter[i] ^= rhs.filter[i];
@@ -61,17 +61,17 @@ HTTP::CharFilter HTTP::CharFilter::operator~() const {
     return n;
 }
 
-HTTP::CharFilter HTTP::CharFilter::operator-(const CharFilter& rhs) const {
+HTTP::CharFilter HTTP::CharFilter::operator-(const CharFilter &rhs) const {
     return *this & ~rhs;
 }
 
-void HTTP::CharFilter::fill(const byte_string& chars) {
+void HTTP::CharFilter::fill(const byte_string &chars) {
     memset(filter, 0, ELEMS);
     // 3 の出どころは 2^3 = 8.
     for (byte_string::size_type i = 0; i < chars.size(); ++i) {
-        byte_type c = chars[i];
+        byte_type c                = chars[i];
         unsigned int element_index = c >> 3;
-        unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
+        unsigned int bit_index     = c & (((unsigned int)1 << 3) - 1);
         filter[element_index] |= (unsigned int)1 << bit_index;
     }
 }
@@ -79,18 +79,20 @@ void HTTP::CharFilter::fill(const byte_string& chars) {
 void HTTP::CharFilter::fill(byte_type from, byte_type to) {
     memset(filter, 0, ELEMS);
     for (; from <= to; ++from) {
-        byte_type c = from;
+        byte_type c                = from;
         unsigned int element_index = c >> 3;
-        unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
+        unsigned int bit_index     = c & (((unsigned int)1 << 3) - 1);
         filter[element_index] |= (unsigned int)1 << bit_index;
-        if (from == to) { break; }
+        if (from == to) {
+            break;
+        }
     }
 }
 
 bool HTTP::CharFilter::includes(byte_type c) const {
     unsigned int element_index = c >> 3;
-    unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
-    int x = (filter[element_index] & ((unsigned int)1 << bit_index));
+    unsigned int bit_index     = c & (((unsigned int)1 << 3) - 1);
+    int x                      = (filter[element_index] & ((unsigned int)1 << bit_index));
     return x;
 }
 
@@ -129,29 +131,31 @@ bool HTTP::CharFilter::includes(byte_type c) const {
 // 0x0f0f = 0b0000111100001111 0xf0f0 = 0b1111000011110000 4
 // 0x00ff = 0b0000000011111111 0xff00 = 0b1111111100000000 8
 
-HTTP::byte_string::size_type    HTTP::CharFilter::size() const {
+HTTP::byte_string::size_type HTTP::CharFilter::size() const {
     byte_string::size_type n = 0;
     for (int i = 0; i < ELEMS; ++i) {
         unsigned int x = filter[i];
-        x = (x & 0x55U) + ((x & 0xaaU) >> 1);
-        x = (x & 0x33U) + ((x & 0xccU) >> 2);
-        x = (x & 0x0fU) + ((x & 0xf0U) >> 4);
+        x              = (x & 0x55U) + ((x & 0xaaU) >> 1);
+        x              = (x & 0x33U) + ((x & 0xccU) >> 2);
+        x              = (x & 0x0fU) + ((x & 0xf0U) >> 4);
         n += x;
     }
     return n;
 }
 
-HTTP::byte_string   HTTP::CharFilter::str() const {
-    HTTP::byte_string   out;
+HTTP::byte_string HTTP::CharFilter::str() const {
+    HTTP::byte_string out;
     out.reserve(size());
     for (unsigned int i = 0; i < 256; ++i) {
         byte_type c = i;
-        if (includes(c)) { out.push_back(c); }
+        if (includes(c)) {
+            out.push_back(c);
+        }
     }
     return out;
 }
 
-std::ostream&   operator<<(std::ostream& ost, const HTTP::CharFilter& f) {
+std::ostream &operator<<(std::ostream &ost, const HTTP::CharFilter &f) {
     return ost << "(" << f.size() << "):[" << f.str() << "]";
 }
 
@@ -174,7 +178,8 @@ const HTTP::CharFilter HTTP::CharFilter::dquote     = "\"";
 const HTTP::CharFilter HTTP::CharFilter::bslash     = "\\";
 const HTTP::CharFilter HTTP::CharFilter::obs_text   = HTTP::CharFilter(0x80, 0xff);
 const HTTP::CharFilter HTTP::CharFilter::vchar      = HTTP::CharFilter(0x21, 0x7e);
-const HTTP::CharFilter HTTP::CharFilter::qdtext     = HTTP::CharFilter::vchar | HTTP::CharFilter::htab | HTTP::CharFilter::obs_text - "\"\\";
+const HTTP::CharFilter HTTP::CharFilter::qdtext
+    = HTTP::CharFilter::vchar | HTTP::CharFilter::htab | HTTP::CharFilter::obs_text - "\"\\";
 const HTTP::CharFilter HTTP::CharFilter::quoted_right = HTTP::CharFilter::vchar | " \t" | HTTP::CharFilter::obs_text;
 
 // parameter      = token "=" ( token / quoted-string )

--- a/src/utils/CharFilter.cpp
+++ b/src/utils/CharFilter.cpp
@@ -19,7 +19,7 @@ HTTP::CharFilter::CharFilter(const CharFilter& other) {
 
 HTTP::CharFilter& HTTP::CharFilter::operator=(const CharFilter& rhs) {
     if (this != &rhs) {
-        memcpy(filter, rhs.filter, 32);
+        memcpy(filter, rhs.filter, ELEMS);
     }
     return *this;
 }
@@ -75,7 +75,7 @@ void HTTP::CharFilter::fill(const byte_string& chars) {
 }
 
 void HTTP::CharFilter::fill(byte_type from, byte_type to) {
-    memset(filter, 0, 32);
+    memset(filter, 0, ELEMS);
     for (; from <= to; ++from) {
         byte_type c = from;
         filter[(c >> 3)] |= (unsigned int)1 << (c & (((unsigned int)1 << 3) - 1));

--- a/src/utils/CharFilter.cpp
+++ b/src/utils/CharFilter.cpp
@@ -1,0 +1,182 @@
+#include "CharFilter.hpp"
+
+HTTP::CharFilter::CharFilter(const byte_string& chars) {
+    fill(chars);
+}
+
+HTTP::CharFilter::CharFilter(const char *chars) {
+    fill(byte_string(chars));
+}
+
+HTTP::CharFilter::CharFilter(uint8_t from, uint8_t to) {
+    fill(from, to);
+}
+
+HTTP::CharFilter::CharFilter(const CharFilter& other) {
+    *this = other;
+}
+
+HTTP::CharFilter& HTTP::CharFilter::operator=(const CharFilter& rhs) {
+    if (this != &rhs) {
+        memcpy(filter, rhs.filter, sizeof(uint64_t) * 4);
+    }
+    return *this;
+}
+
+HTTP::CharFilter& HTTP::CharFilter::operator=(const byte_string& rhs) {
+    fill(rhs);
+    return *this;
+}
+
+HTTP::CharFilter HTTP::CharFilter::operator|(const CharFilter& rhs) const {
+    CharFilter n(*this);
+    for (int i = 0; i < 4; ++i) {
+        n.filter[i] |= rhs.filter[i];
+    }
+    return n;
+}
+
+HTTP::CharFilter HTTP::CharFilter::operator&(const CharFilter& rhs) const {
+    CharFilter n(*this);
+    for (int i = 0; i < 4; ++i) {
+        n.filter[i] &= rhs.filter[i];
+    }
+    return n;
+}
+
+HTTP::CharFilter HTTP::CharFilter::operator^(const CharFilter& rhs) const {
+    CharFilter n(*this);
+    for (int i = 0; i < 4; ++i) {
+        n.filter[i] ^= rhs.filter[i];
+    }
+    return n;
+}
+
+HTTP::CharFilter HTTP::CharFilter::operator~() const {
+    CharFilter n(*this);
+    for (int i = 0; i < 4; ++i) {
+        n.filter[i] = ~n.filter[i];
+    }
+    return n;
+}
+
+HTTP::CharFilter HTTP::CharFilter::operator-(const CharFilter& rhs) const {
+    return *this & ~rhs;
+}
+
+void HTTP::CharFilter::fill(const byte_string& chars) {
+    memset(filter, 0, sizeof(uint64_t) * 4);
+    // 6 の出どころは 2^6 = 64.
+    for (byte_string::size_type i = 0; i < chars.size(); ++i) {
+        uint8_t c = chars[i];
+        filter[(c >> 6)] |= (uint64_t)1 << (c & (((uint64_t)1 << 6) - 1));
+    }
+}
+
+void HTTP::CharFilter::fill(uint8_t from, uint8_t to) {
+    memset(filter, 0, sizeof(uint64_t) * 4);
+    for (; from <= to; ++from) {
+        uint8_t c = from;
+        filter[(c >> 6)] |= (uint64_t)1 << (c & (((uint64_t)1 << 6) - 1));
+        if (from == to) { break; }
+    }
+}
+
+bool HTTP::CharFilter::includes(uint8_t c) const {
+    uint64_t x = (filter[(c >> 6)] & ((uint64_t)1 << (c & (((uint64_t)1 << 6) - 1))));
+    return x;
+}
+
+// 0x5555..
+// 0x5  = 0b0101
+// 0x55 = 0b01010101
+// 0xa  = 0b1010
+// 0xaa = 0b10101010
+
+// uint8_t x;
+// x & 0x55 = x & 0b01010101 -> x の偶数ビットのみ残す
+// x & 0xaa = x & 0b10101010 -> x の奇数ビットのみ残す
+// (x & 0xaa) >> 1 -> x の奇数ビットを偶数ビットにずらす
+// (x & 0x55) + ((x & 0xaa) >> 1) -> xの"隣り合うビット" [0,1] [2,3] [4,5] [6,7] の和
+
+// x = 167         = 0b 10 10 01 11
+// (x & 0x55)      = 0b 00 00 01 01
+// (x & 0xaa)      = 0b 10 10 00 10
+// (x & 0xaa) >> 1 = 0b 01 01 00 01
+// (x & 0x55) + ((x & 0xaa) >> 1)
+//                 = 0b 01 01 01 10 = y (popcount in 2bit)
+
+// 0x33            = 0b 00 11 00 11
+// 0xcc            = 0b 11 00 11 00
+// (y & 0x33)      = 0b 00 01 00 10
+// (y & 0xcc)      = 0b 01 00 01 00
+// (y & 0xcc) >> 2 = 0b 00 01 00 01
+// (y & 0x33) + ((y & 0xcc) >> 2)
+//                 = 0b 00 10 00 11 = z (popcount in 4bit)
+
+// 0x0f            = 0b 00 00 11 11
+// 0xf0            = 0b 11 11 00 00
+
+// 0x5555 = 0b0101010101010101 0xaaaa = 0b1010101010101010 1
+// 0x3333 = 0b0011001100110011 0xcccc = 0b1100110011001100 2
+// 0x0f0f = 0b0000111100001111 0xf0f0 = 0b1111000011110000 4
+// 0x00ff = 0b0000000011111111 0xff00 = 0b1111111100000000 8
+
+HTTP::byte_string::size_type    HTTP::CharFilter::size() const {
+    byte_string::size_type n = 0;
+    for (int i = 0; i < 4; ++i) {
+        uint64_t x = filter[i];
+        x = (x & 0x5555555555555555UL) + ((x & 0xaaaaaaaaaaaaaaaaUL) >> 1);
+        x = (x & 0x3333333333333333UL) + ((x & 0xccccccccccccccccUL) >> 2);
+        x = (x & 0x0f0f0f0f0f0f0f0fUL) + ((x & 0xf0f0f0f0f0f0f0f0UL) >> 4);
+        x = (x & 0x00ff00ff00ff00ffUL) + ((x & 0xff00ff00ff00ff00UL) >> 8);
+        x = (x & 0x0000ffff0000ffffUL) + ((x & 0xffff0000ffff0000UL) >> 16);
+        x = (x & 0x00000000ffffffffUL) + ((x & 0xffffffff00000000UL) >> 32);
+        n += x;
+    }
+    return n;
+}
+
+HTTP::byte_string   HTTP::CharFilter::str() const {
+    HTTP::byte_string   out;
+    out.reserve(size());
+    for (unsigned int i = 0; i < 4 * 8 * sizeof(uint64_t); ++i) {
+        uint8_t c = i;
+        if (includes(c)) { out.push_back(c); }
+    }
+    return out;
+}
+
+std::ostream&   operator<<(std::ostream& ost, const HTTP::CharFilter& f) {
+    return ost << "(" << f.size() << "):[" << f.str() << "]";
+}
+
+const HTTP::CharFilter HTTP::CharFilter::alpha_low  = HTTP::Charset::alpha_low;
+const HTTP::CharFilter HTTP::CharFilter::alpha_up   = HTTP::Charset::alpha_up;
+const HTTP::CharFilter HTTP::CharFilter::alpha      = HTTP::Charset::alpha;
+const HTTP::CharFilter HTTP::CharFilter::digit      = HTTP::Charset::digit;
+const HTTP::CharFilter HTTP::CharFilter::hexdig     = HTTP::Charset::hexdig;
+const HTTP::CharFilter HTTP::CharFilter::unreserved = HTTP::Charset::unreserved;
+const HTTP::CharFilter HTTP::CharFilter::gen_delims = HTTP::Charset::gen_delims;
+const HTTP::CharFilter HTTP::CharFilter::sub_delims = HTTP::Charset::sub_delims;
+const HTTP::CharFilter HTTP::CharFilter::tchar      = HTTP::Charset::tchar;
+const HTTP::CharFilter HTTP::CharFilter::sp         = HTTP::Charset::sp;
+const HTTP::CharFilter HTTP::CharFilter::ws         = HTTP::Charset::ws;
+const HTTP::CharFilter HTTP::CharFilter::crlf       = HTTP::Charset::crlf;
+const HTTP::CharFilter HTTP::CharFilter::cr         = "\r";
+const HTTP::CharFilter HTTP::CharFilter::lf         = HTTP::Charset::lf;
+const HTTP::CharFilter HTTP::CharFilter::htab       = "\t";
+const HTTP::CharFilter HTTP::CharFilter::dquote     = "\"";
+const HTTP::CharFilter HTTP::CharFilter::bslash     = "\\";
+const HTTP::CharFilter HTTP::CharFilter::obs_text   = HTTP::CharFilter(0x80, 0xff);
+const HTTP::CharFilter HTTP::CharFilter::vchar      = HTTP::CharFilter(0x21, 0x7e);
+const HTTP::CharFilter HTTP::CharFilter::qdtext     = HTTP::CharFilter::vchar | HTTP::CharFilter::htab | HTTP::CharFilter::obs_text - "\"\\";
+const HTTP::CharFilter HTTP::CharFilter::quoted_right = HTTP::CharFilter::vchar | " \t" | HTTP::CharFilter::obs_text;
+
+// parameter      = token "=" ( token / quoted-string )
+// quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+// qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+//                ;               !     #-[        ]-~
+//                ; HTAB + 表示可能文字, ただし "(ダブルクオート) と \(バッスラ) を除く
+// obs-text       = %x80-FF ; extended ASCII
+// quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )

--- a/src/utils/CharFilter.cpp
+++ b/src/utils/CharFilter.cpp
@@ -70,7 +70,9 @@ void HTTP::CharFilter::fill(const byte_string& chars) {
     // 3 の出どころは 2^3 = 8.
     for (byte_string::size_type i = 0; i < chars.size(); ++i) {
         byte_type c = chars[i];
-        filter[(c >> 3)] |= (unsigned int)1 << (c & (((unsigned int)1 << 3) - 1));
+        unsigned int element_index = c >> 3;
+        unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
+        filter[element_index] |= (unsigned int)1 << bit_index;
     }
 }
 
@@ -78,13 +80,17 @@ void HTTP::CharFilter::fill(byte_type from, byte_type to) {
     memset(filter, 0, ELEMS);
     for (; from <= to; ++from) {
         byte_type c = from;
-        filter[(c >> 3)] |= (unsigned int)1 << (c & (((unsigned int)1 << 3) - 1));
+        unsigned int element_index = c >> 3;
+        unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
+        filter[element_index] |= (unsigned int)1 << bit_index;
         if (from == to) { break; }
     }
 }
 
 bool HTTP::CharFilter::includes(byte_type c) const {
-    int x = (filter[(c >> 3)] & ((unsigned int)1 << (c & (((unsigned int)1 << 3) - 1))));
+    unsigned int element_index = c >> 3;
+    unsigned int bit_index = c & (((unsigned int)1 << 3) - 1);
+    int x = (filter[element_index] & ((unsigned int)1 << bit_index));
     return x;
 }
 

--- a/src/utils/CharFilter.hpp
+++ b/src/utils/CharFilter.hpp
@@ -1,79 +1,79 @@
 #ifndef CHARFILTER_HPP
-# define CHARFILTER_HPP
-# include <iostream>
-# include <string>
-# include <map>
-# include "http.hpp"
+#define CHARFILTER_HPP
+#include "http.hpp"
+#include <iostream>
+#include <map>
+#include <string>
 
 // 全体で共通して使うenum, 型, 定数, フリー関数など
 
 namespace HTTP {
 
-    // 単純な文字集合クラス
-    class CharFilter {
-    private:
-        unsigned char   filter[32];
+// 単純な文字集合クラス
+class CharFilter {
+private:
+    unsigned char filter[32];
 
-    public:
-        CharFilter(const byte_string& chars);
-        CharFilter(const char* chars);
-        CharFilter(const CharFilter& other);
-        // by exclusive char-range
-        CharFilter(byte_type from, byte_type to);
+public:
+    CharFilter(const byte_string &chars);
+    CharFilter(const char *chars);
+    CharFilter(const CharFilter &other);
+    // by exclusive char-range
+    CharFilter(byte_type from, byte_type to);
 
-        CharFilter& operator=(const CharFilter& rhs);
-        CharFilter& operator=(const byte_string& rhs);
+    CharFilter &operator=(const CharFilter &rhs);
+    CharFilter &operator=(const byte_string &rhs);
 
-        // set union
-        CharFilter  operator|(const CharFilter& rhs) const;
-        // set intersection
-        CharFilter  operator&(const CharFilter& rhs) const;
-        // set symmetric difference
-        CharFilter  operator^(const CharFilter& rhs) const;
-        // set complement
-        CharFilter  operator~() const;
-        CharFilter  operator-(const CharFilter& rhs) const;
+    // set union
+    CharFilter operator|(const CharFilter &rhs) const;
+    // set intersection
+    CharFilter operator&(const CharFilter &rhs) const;
+    // set symmetric difference
+    CharFilter operator^(const CharFilter &rhs) const;
+    // set complement
+    CharFilter operator~() const;
+    CharFilter operator-(const CharFilter &rhs) const;
 
-        // 文字集合を文字列`chars`を使って初期化する
-        void        fill(const byte_string& chars);
-        void        fill(byte_type from, byte_type to);
-        // `c` が文字集合に含まれるかどうか
-        bool        includes(byte_type c) const;
-        // 文字集合のサイズ
-        byte_string::size_type  size() const;
+    // 文字集合を文字列`chars`を使って初期化する
+    void fill(const byte_string &chars);
+    void fill(byte_type from, byte_type to);
+    // `c` が文字集合に含まれるかどうか
+    bool includes(byte_type c) const;
+    // 文字集合のサイズ
+    byte_string::size_type size() const;
 
-        // アルファベット・小文字
-        static const CharFilter alpha_low;
-        // アルファベット・大文字
-        static const CharFilter alpha_up;
-        // アルファベット
-        static const CharFilter alpha;
-        // 数字
-        static const CharFilter digit;
-        // 16進数における数字
-        static const CharFilter hexdig;
-        // HTTPにおける非予約文字
-        static const CharFilter unreserved;
-        static const CharFilter gen_delims;
-        static const CharFilter sub_delims;
-        static const CharFilter tchar;
-        static const CharFilter sp;
-        static const CharFilter ws;
-        static const CharFilter crlf;
-        static const CharFilter cr;
-        static const CharFilter lf;
-        static const CharFilter htab;
-        static const CharFilter dquote;
-        static const CharFilter bslash;
-        static const CharFilter obs_text;
-        static const CharFilter vchar;
-        static const CharFilter qdtext;
-        static const CharFilter quoted_right;
+    // アルファベット・小文字
+    static const CharFilter alpha_low;
+    // アルファベット・大文字
+    static const CharFilter alpha_up;
+    // アルファベット
+    static const CharFilter alpha;
+    // 数字
+    static const CharFilter digit;
+    // 16進数における数字
+    static const CharFilter hexdig;
+    // HTTPにおける非予約文字
+    static const CharFilter unreserved;
+    static const CharFilter gen_delims;
+    static const CharFilter sub_delims;
+    static const CharFilter tchar;
+    static const CharFilter sp;
+    static const CharFilter ws;
+    static const CharFilter crlf;
+    static const CharFilter cr;
+    static const CharFilter lf;
+    static const CharFilter htab;
+    static const CharFilter dquote;
+    static const CharFilter bslash;
+    static const CharFilter obs_text;
+    static const CharFilter vchar;
+    static const CharFilter qdtext;
+    static const CharFilter quoted_right;
 
-        byte_string str() const;
-    };
-}
+    byte_string str() const;
+};
+} // namespace HTTP
 
-std::ostream&   operator<<(std::ostream& ost, const HTTP::CharFilter& f);
+std::ostream &operator<<(std::ostream &ost, const HTTP::CharFilter &f);
 
 #endif

--- a/src/utils/CharFilter.hpp
+++ b/src/utils/CharFilter.hpp
@@ -12,14 +12,14 @@ namespace HTTP {
     // 単純な文字集合クラス
     class CharFilter {
     private:
-        uint64_t    filter[4];
+        unsigned char   filter[32];
 
     public:
         CharFilter(const byte_string& chars);
         CharFilter(const char* chars);
         CharFilter(const CharFilter& other);
         // by exclusive char-range
-        CharFilter(uint8_t from, uint8_t to);
+        CharFilter(byte_type from, byte_type to);
 
         CharFilter& operator=(const CharFilter& rhs);
         CharFilter& operator=(const byte_string& rhs);
@@ -36,9 +36,9 @@ namespace HTTP {
 
         // 文字集合を文字列`chars`を使って初期化する
         void        fill(const byte_string& chars);
-        void        fill(uint8_t from, uint8_t to);
+        void        fill(byte_type from, byte_type to);
         // `c` が文字集合に含まれるかどうか
-        bool        includes(uint8_t c) const;
+        bool        includes(byte_type c) const;
         // 文字集合のサイズ
         byte_string::size_type  size() const;
 

--- a/src/utils/CharFilter.hpp
+++ b/src/utils/CharFilter.hpp
@@ -1,0 +1,79 @@
+#ifndef CHARFILTER_HPP
+# define CHARFILTER_HPP
+# include <iostream>
+# include <string>
+# include <map>
+# include "http.hpp"
+
+// 全体で共通して使うenum, 型, 定数, フリー関数など
+
+namespace HTTP {
+
+    // 単純な文字集合クラス
+    class CharFilter {
+    private:
+        uint64_t    filter[4];
+
+    public:
+        CharFilter(const byte_string& chars);
+        CharFilter(const char* chars);
+        CharFilter(const CharFilter& other);
+        // by exclusive char-range
+        CharFilter(uint8_t from, uint8_t to);
+
+        CharFilter& operator=(const CharFilter& rhs);
+        CharFilter& operator=(const byte_string& rhs);
+
+        // set union
+        CharFilter  operator|(const CharFilter& rhs) const;
+        // set intersection
+        CharFilter  operator&(const CharFilter& rhs) const;
+        // set symmetric difference
+        CharFilter  operator^(const CharFilter& rhs) const;
+        // set complement
+        CharFilter  operator~() const;
+        CharFilter  operator-(const CharFilter& rhs) const;
+
+        // 文字集合を文字列`chars`を使って初期化する
+        void        fill(const byte_string& chars);
+        void        fill(uint8_t from, uint8_t to);
+        // `c` が文字集合に含まれるかどうか
+        bool        includes(uint8_t c) const;
+        // 文字集合のサイズ
+        byte_string::size_type  size() const;
+
+        // アルファベット・小文字
+        static const CharFilter alpha_low;
+        // アルファベット・大文字
+        static const CharFilter alpha_up;
+        // アルファベット
+        static const CharFilter alpha;
+        // 数字
+        static const CharFilter digit;
+        // 16進数における数字
+        static const CharFilter hexdig;
+        // HTTPにおける非予約文字
+        static const CharFilter unreserved;
+        static const CharFilter gen_delims;
+        static const CharFilter sub_delims;
+        static const CharFilter tchar;
+        static const CharFilter sp;
+        static const CharFilter ws;
+        static const CharFilter crlf;
+        static const CharFilter cr;
+        static const CharFilter lf;
+        static const CharFilter htab;
+        static const CharFilter dquote;
+        static const CharFilter bslash;
+        static const CharFilter obs_text;
+        static const CharFilter vchar;
+        static const CharFilter qdtext;
+        static const CharFilter quoted_right;
+
+        byte_string str() const;
+    };
+}
+
+std::ostream&   operator<<(std::ostream& ost, const HTTP::CharFilter& f);
+
+#endif

--- a/src/utils/IndexRange.cpp
+++ b/src/utils/IndexRange.cpp
@@ -1,0 +1,35 @@
+#include "IndexRange.hpp"
+
+IndexRange::IndexRange():
+    pair(0, 0) {}
+
+IndexRange::IndexRange(ssize_t f, ssize_t t):
+    pair(f, t) {}
+
+bool        IndexRange::is_invalid() const {
+    return first > second;
+}
+
+ssize_t     IndexRange::length() const {
+    return second - first;
+}
+
+IndexRange::first_type& IndexRange::from() {
+    return first;
+}
+
+const IndexRange::first_type& IndexRange::from() const {
+    return first;
+}
+
+IndexRange::first_type& IndexRange::to() {
+    return second;
+}
+
+const IndexRange::first_type& IndexRange::to() const {
+    return second;
+}
+
+std::ostream&   operator<<(std::ostream& out, const IndexRange& r) {
+    return out << "[" << r.first << "," << r.second << ")";
+}

--- a/src/utils/IndexRange.cpp
+++ b/src/utils/IndexRange.cpp
@@ -1,35 +1,33 @@
 #include "IndexRange.hpp"
 
-IndexRange::IndexRange():
-    pair(0, 0) {}
+IndexRange::IndexRange() : pair(0, 0) {}
 
-IndexRange::IndexRange(ssize_t f, ssize_t t):
-    pair(f, t) {}
+IndexRange::IndexRange(ssize_t f, ssize_t t) : pair(f, t) {}
 
-bool        IndexRange::is_invalid() const {
+bool IndexRange::is_invalid() const {
     return first > second;
 }
 
-ssize_t     IndexRange::length() const {
+ssize_t IndexRange::length() const {
     return second - first;
 }
 
-IndexRange::first_type& IndexRange::from() {
+IndexRange::first_type &IndexRange::from() {
     return first;
 }
 
-const IndexRange::first_type& IndexRange::from() const {
+const IndexRange::first_type &IndexRange::from() const {
     return first;
 }
 
-IndexRange::first_type& IndexRange::to() {
+IndexRange::first_type &IndexRange::to() {
     return second;
 }
 
-const IndexRange::first_type& IndexRange::to() const {
+const IndexRange::first_type &IndexRange::to() const {
     return second;
 }
 
-std::ostream&   operator<<(std::ostream& out, const IndexRange& r) {
+std::ostream &operator<<(std::ostream &out, const IndexRange &r) {
     return out << "[" << r.first << "," << r.second << ")";
 }

--- a/src/utils/IndexRange.hpp
+++ b/src/utils/IndexRange.hpp
@@ -1,23 +1,23 @@
 #ifndef INDEXRANGE_HPP
-# define INDEXRANGE_HPP
-# include <string>
-# include <utility>
-# include <iostream>
-# include "test_common.hpp"
+#define INDEXRANGE_HPP
+#include "test_common.hpp"
+#include <iostream>
+#include <string>
+#include <utility>
 
-struct IndexRange: public std::pair<ssize_t, ssize_t> {
+struct IndexRange : public std::pair<ssize_t, ssize_t> {
     IndexRange();
     IndexRange(ssize_t f, ssize_t t);
-    bool                is_invalid() const;
-    ssize_t             length() const;
+    bool is_invalid() const;
+    ssize_t length() const;
 
-    first_type&         from();
-    const first_type&   from() const;
+    first_type &from();
+    const first_type &from() const;
 
-    second_type&        to();
-    const second_type&  to() const;
+    second_type &to();
+    const second_type &to() const;
 };
 
-std::ostream&   operator<<(std::ostream& out, const IndexRange& r);
+std::ostream &operator<<(std::ostream &out, const IndexRange &r);
 
 #endif

--- a/src/utils/IndexRange.hpp
+++ b/src/utils/IndexRange.hpp
@@ -1,0 +1,23 @@
+#ifndef INDEXRANGE_HPP
+# define INDEXRANGE_HPP
+# include <string>
+# include <utility>
+# include <iostream>
+# include "test_common.hpp"
+
+struct IndexRange: public std::pair<ssize_t, ssize_t> {
+    IndexRange();
+    IndexRange(ssize_t f, ssize_t t);
+    bool                is_invalid() const;
+    ssize_t             length() const;
+
+    first_type&         from();
+    const first_type&   from() const;
+
+    second_type&        to();
+    const second_type&  to() const;
+};
+
+std::ostream&   operator<<(std::ostream& out, const IndexRange& r);
+
+#endif

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -1,0 +1,340 @@
+#ifndef LIGHTSTRING_HPP
+# define LIGHTSTRING_HPP
+# include <string>
+# include <algorithm>
+# include "CharFilter.hpp"
+# include "IndexRange.hpp"
+
+const std::string blank_str = "";
+
+// 別のstringの一部分をiteratorペアとして参照する軽量string
+// C++17以降にある string_view と思えば良いか
+template <class T>
+class LightString {
+public:
+
+    typedef T                                       element;
+    typedef std::basic_string<T>                    string_class;
+    typedef HTTP::CharFilter                        filter_type;
+    typedef typename string_class::iterator         iterator;
+    typedef typename string_class::const_iterator   const_iterator;
+    typedef typename string_class::size_type        size_type;
+    static const typename string_class::size_type   npos = string_class::npos;
+    typedef typename string_class::reference        reference;
+    typedef typename string_class::const_reference  const_reference;
+
+private:
+
+    // 参照先string
+    const string_class& base;
+    // `base`のこのオブジェクトが参照している部分の最初のインデックス
+    // first <= last が成り立つ
+    size_type           first;
+    // `base`のこのオブジェクトが参照している部分の最後のインデックス + 1
+    // first <= last が成り立つ
+    // last <= base.size() が成り立つ
+    size_type           last;
+
+public:
+
+    LightString(): base(blank_str) {
+        first = last;
+    }
+
+    LightString(const string_class& str):
+        base(str),
+        first(0),
+        last(str.length()) {}
+
+    LightString(const string_class& str, const_iterator f, const_iterator l):
+        base(str),
+        first(std::distance(str.begin(), f)),
+        last(std::max(first, std::min(str.size(), (size_type)std::distance(str.begin(), l)))) {}
+
+    LightString(const string_class& str, size_type fi, size_type li = npos):
+        base(str),
+        first(fi),
+        last(std::max(first, std::min(str.size(), li))) {
+            DXOUT(first << ":" << last);
+        }
+
+    LightString(const string_class& str, const IndexRange& range):
+        base(str),
+        first(range.first),
+        last(std::max(first, std::min(str.size(), range.second))) {}
+
+    LightString(const LightString& lstr, size_type fi, size_type li = npos):
+        base(lstr.base),
+        first(lstr.first + fi),
+        last(std::max(first, lstr.first + std::min(lstr.size(), li))) {}
+
+    LightString& operator=(const LightString& rhs) {
+        const_cast<string_class&>(base) = rhs.base;
+        first = rhs.first;
+        last = rhs.last;
+        return *this;
+    }
+
+    LightString& operator=(const string_class& rhs) {
+        const_cast<string_class&>(base) = rhs;
+        first = 0;
+        last = rhs.length();
+        return *this;
+    }
+
+    // 参照先文字列を取得
+    const string_class& get_base() const {
+        return base;
+    }
+
+    // std::string を生成
+    string_class    str() const {
+        if (first == last) { return ""; }
+        return string_class(base.begin() + first, base.begin() + last);
+    }
+
+    size_type       size() const {
+        return last - first;
+    }
+
+    size_type       length() const {
+        return last - first;
+    }
+
+    iterator        begin() {
+        return base.begin() + first;
+    }
+
+    const_iterator  begin() const {
+        return base.begin() + first;
+    }
+
+    iterator        end() {
+        return base.begin() + last;
+    }
+
+    const_iterator  end() const {
+        return base.begin() + last;
+    }
+
+    const_reference operator[](size_type pos) const {
+        return base[first + pos];
+    }
+
+    reference       operator[](size_type pos) {
+        return base[first + pos];
+    }
+
+    element         cat(size_type pos) {
+        return base[first + pos];
+    }
+
+    // `str` に含まれる文字が(LightString内で)最初に出現する位置を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       find_first_of(const filter_type& filter, size_type pos = 0) const {
+        size_type d = length();
+        if (pos >= d) {
+            return npos;
+        }
+        for (typename string_class::size_type i = pos; i < size(); ++i) {
+            if (filter.includes(operator[](i))) {
+                return i;
+            }
+        }
+        return npos;
+    }
+
+    // `str` に含まれる文字が(LightString内で)最後に出現する位置を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       find_last_of(const filter_type& filter, size_type pos = 0) const {
+        size_type d = length();
+        if (pos >= d) {
+            return npos;
+        }
+        for (typename string_class::size_type i = last; first + pos < i;) {
+            --i;
+            if (filter.includes(base[i])) {
+                return i - first;
+            }
+        }
+        return npos;
+    }
+
+    // `str` に含まれない文字が(LightString内で)最初に出現する位置を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       find_first_not_of(const filter_type& filter, size_type pos = 0) const {
+        size_type d = length();
+        if (pos >= d) {
+            return npos;
+        }
+        if (first == last) {
+            return npos;
+        }
+        for (size_type i = pos; i < size(); ++i) {
+            if (!filter.includes(operator[](i))) {
+                return i;
+            }
+        }
+        return npos;
+    }
+
+    // `str` に含まれる文字が(LightString内で)最後に出現する位置を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       find_last_not_of(const filter_type& filter, size_type pos = 0) const {
+        size_type d = length();
+        if (pos >= d) {
+            return npos;
+        }
+        if (first == last) {
+            return npos;
+        }
+        for (size_type i = size(); 0 + pos < i;) {
+            --i;
+            if (!filter.includes(operator[](i))) {
+                return i;
+            }
+        }
+        return npos;
+    }
+
+    // `str`が最初に出現する位置(= 先頭文字のインデックス)を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       find(const string_class& str, size_type pos = 0) const {
+        for (size_type i = pos; i + str.size() <= size(); ++i) {
+            size_type j = 0;
+            for (; j < str.size() && operator[](i + j) == str[j]; ++j);
+            if (j == str.size()) {
+                return i;
+            }
+        }
+        return npos;
+    }
+
+    // `str`が最後に出現する位置(= 先頭文字のインデックス)を返す
+    // `pos`が指定された場合, 位置`pos`以降のみを検索する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    size_type       rfind(const string_class& str, size_type pos = 0) const {
+        for (size_type i = size() - str.size(); pos <= i;) {
+            size_type j = 0;
+            for (; j < str.size() && operator[](i + j) == str[j]; ++j);
+            if (j == str.size()) {
+                return i;
+            }
+            if (pos == i) { break; }
+            --i;
+        }
+        return npos;
+    }
+
+    // 指定した位置`pos`から始まる(最大)長さ`n`の区間を参照する LightString を生成して返す
+    // `n`を指定しなかった場合, 新たな LightString の終端は現在の終端と一致する
+    // 位置は参照先文字列ではなく LightString 先頭からの相対位置
+    LightString substr(size_type pos = 0, size_type n = std::string::npos) const {
+        if (pos == std::string::npos) {
+            return LightString(*this, size(), size());
+        }
+        if (n == std::string::npos) {
+            return LightString(*this, pos, size());
+        }
+        size_type   rlen = size() - pos;
+        if (n < rlen) { // pos + n < size()
+            rlen = n;
+        }
+        return LightString(*this, pos, pos + rlen);
+    }
+
+    // 「`pos`以降で最初に`filter`にマッチしなくなる位置」の直前までを参照する LightString を生成して返す
+    // `pos`以前の部分も含まれることに注意.
+    // ※ substr(0, find_first_not_of(filter, pos)) と等価
+    LightString substr_while(const filter_type& filter, size_type pos = 0) const {
+        size_type n = find_first_not_of(filter, pos);
+        return substr(0, n);
+    }
+
+    // 「`pos`以降で最初に`filter`にマッチしなくなる位置」から後の部分参照する LightString を生成して返す
+    // ※ substr(find_first_not_of(filter, pos)) と等価
+    LightString substr_after(const filter_type& filter, size_type pos = 0) const {
+        size_type n = find_first_not_of(filter, pos);
+        return substr(n);
+    }
+
+    // 「`pos`以降で最初に`filter`にマッチする位置」の直前までを参照する LightString を生成して返す
+    // `pos`以前の部分も含まれることに注意.
+    // ※ substr(0, find_first_of(filter, pos)) と等価
+    LightString substr_before(const filter_type& filter, size_type pos = 0) const {
+        size_type n = find_first_of(filter, pos);
+        return substr(0, n);
+    }
+
+    // 「`pos`以降で最初に`filter`にマッチする位置」から後の部分参照する LightString を生成して返す
+    // ※ substr(find_first_of(filter, pos)) と等価
+    LightString substr_from(const filter_type& filter, size_type pos = 0) const {
+        size_type n = find_first_of(filter, pos);
+        return substr(n);
+    }
+
+    std::vector<LightString>    split(const filter_type& filter) const {
+        std::vector<LightString>    rv;
+        size_type word_from = 0;
+        size_type word_to = 0;
+        bool prev_is_sp = true;
+        for (size_type i = 0; i <= size(); ++i) {
+            if (i == size() || filter.includes(operator[](i))) {
+                word_to = i;
+                if (prev_is_sp) {
+                    word_from = i;
+                }
+                // DXOUT("substr(" << word_from << ", " << word_to - word_from << ")");
+                rv.push_back(substr(word_from, word_to - word_from));
+                prev_is_sp = true;
+            } else {
+                if (prev_is_sp) {
+                    word_from = i;
+                }
+                prev_is_sp = false;
+            }
+        }
+        return rv;
+    }
+
+    // 文字集合`fil`内の文字を左側について切り落とした新たなLightStringを返す
+    LightString ltrim(const filter_type& fil) const {
+        size_type first = find_first_not_of(fil);
+        if (first == npos) {
+            return LightString(*this, size(), size());
+        } else {
+            return LightString(*this, first, size());
+        }
+    }
+
+    // 文字集合`fil`内の文字を右側について切り落とした新たなLightStringを返す
+    LightString rtrim(const filter_type& fil) const {
+        size_type last = find_last_not_of(fil);
+        if (last == npos) {
+            return LightString(*this, 0, 0);
+        } else {
+            return LightString(*this, 0, last + 1);
+        }
+    }
+
+    // 文字集合`fil`内の文字を左右から切り落とした新たなLightStringを返す
+    LightString trim(const filter_type& fil) const {
+        return ltrim(fil).rtrim(fil);
+    }
+};
+
+namespace HTTP {
+    typedef LightString<byte_type>  light_string;
+}
+
+template <class T>
+std::ostream&   operator<<(std::ostream& out, const LightString<T>& ls) {
+    return out << typename LightString<T>::string_class(ls.begin(), ls.end());
+}
+
+#endif

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -219,14 +219,13 @@ public:
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
     size_type       rfind(const string_class& str, size_type pos = 0) const {
-        for (size_type i = size() - str.size(); pos <= i;) {
+        for (size_type i = size() - str.size(); pos <= i; --i) {
             size_type j = 0;
             for (; j < str.size() && operator[](i + j) == str[j]; ++j);
             if (j == str.size()) {
                 return i;
             }
             if (pos == i) { break; }
-            --i;
         }
         return npos;
     }
@@ -329,7 +328,7 @@ public:
 };
 
 namespace HTTP {
-    typedef LightString<byte_type>  light_string;
+    typedef LightString<char_type>  light_string;
 }
 
 template <class T>

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -1,9 +1,9 @@
 #ifndef LIGHTSTRING_HPP
-# define LIGHTSTRING_HPP
-# include <string>
-# include <algorithm>
-# include "CharFilter.hpp"
-# include "IndexRange.hpp"
+#define LIGHTSTRING_HPP
+#include "CharFilter.hpp"
+#include "IndexRange.hpp"
+#include <algorithm>
+#include <string>
 
 const std::string blank_str = "";
 
@@ -13,113 +13,103 @@ const std::string blank_str = "";
 template <class T>
 class LightString {
 public:
-
-    typedef T                                       element;
-    typedef std::basic_string<T>                    string_class;
-    typedef HTTP::CharFilter                        filter_type;
-    typedef typename string_class::iterator         iterator;
-    typedef typename string_class::const_iterator   const_iterator;
-    typedef typename string_class::size_type        size_type;
-    static const typename string_class::size_type   npos = string_class::npos;
-    typedef typename string_class::reference        reference;
-    typedef typename string_class::const_reference  const_reference;
+    typedef T element;
+    typedef std::basic_string<T> string_class;
+    typedef HTTP::CharFilter filter_type;
+    typedef typename string_class::iterator iterator;
+    typedef typename string_class::const_iterator const_iterator;
+    typedef typename string_class::size_type size_type;
+    static const typename string_class::size_type npos = string_class::npos;
+    typedef typename string_class::reference reference;
+    typedef typename string_class::const_reference const_reference;
 
 private:
-
     // 参照先string
-    string_class const* base;
+    string_class const *base;
     // `base`のこのオブジェクトが参照している部分の最初のインデックス
     // first <= last が成り立つ
-    size_type           first;
+    size_type first;
     // `base`のこのオブジェクトが参照している部分の最後のインデックス + 1
     // first <= last が成り立つ
     // last <= base.size() が成り立つ
-    size_type           last;
+    size_type last;
 
 public:
-
-    LightString(): base(&blank_str) {
+    LightString() : base(&blank_str) {
         first = last = blank_str.size();
     }
 
-    LightString(const string_class& str):
-        base(&str),
-        first(0),
-        last(str.length()) {}
+    LightString(const string_class &str) : base(&str), first(0), last(str.length()) {}
 
-    LightString(const string_class& str, const_iterator f, const_iterator l):
-        base(&str),
-        first(std::distance(str.begin(), f)),
-        last(std::max(first, std::min(str.size(), (size_type)std::distance(str.begin(), l)))) {}
+    LightString(const string_class &str, const_iterator f, const_iterator l)
+        : base(&str)
+        , first(std::distance(str.begin(), f))
+        , last(std::max(first, std::min(str.size(), (size_type)std::distance(str.begin(), l)))) {}
 
-    LightString(const string_class& str, size_type fi, size_type li = npos):
-        base(&str),
-        first(fi),
-        last(std::max(first, std::min(str.size(), li))) {
-            DXOUT(first << ":" << last);
-        }
+    LightString(const string_class &str, size_type fi, size_type li = npos)
+        : base(&str), first(fi), last(std::max(first, std::min(str.size(), li))) {
+        DXOUT(first << ":" << last);
+    }
 
-    LightString(const string_class& str, const IndexRange& range):
-        base(&str),
-        first(range.first),
-        last(std::max(first, std::min(str.size(), range.second))) {}
+    LightString(const string_class &str, const IndexRange &range)
+        : base(&str), first(range.first), last(std::max(first, std::min(str.size(), range.second))) {}
 
-    LightString(const LightString& lstr, size_type fi, size_type li = npos):
-        base(lstr.base),
-        first(lstr.first + fi),
-        last(std::max(first, lstr.first + std::min(lstr.size(), li))) {}
+    LightString(const LightString &lstr, size_type fi, size_type li = npos)
+        : base(lstr.base), first(lstr.first + fi), last(std::max(first, lstr.first + std::min(lstr.size(), li))) {}
 
-    LightString& operator=(const LightString& rhs) {
-        base = rhs.base;
+    LightString &operator=(const LightString &rhs) {
+        base  = rhs.base;
         first = rhs.first;
-        last = rhs.last;
+        last  = rhs.last;
         return *this;
     }
 
-    LightString& operator=(const string_class& rhs) {
-        base = &rhs;
+    LightString &operator=(const string_class &rhs) {
+        base  = &rhs;
         first = 0;
-        last = rhs.length();
+        last  = rhs.length();
         return *this;
     }
 
     // 参照先文字列を取得
-    const string_class& get_base() const {
+    const string_class &get_base() const {
         return *base;
     }
 
     // std::string を生成
-    string_class    str() const {
-        if (!base || first == last) { return ""; }
+    string_class str() const {
+        if (!base || first == last) {
+            return "";
+        }
         return string_class(base->begin() + first, base->begin() + last);
     }
 
     // ダブルクオートで囲んだ std::string を生成
-    string_class    qstr() const {
+    string_class qstr() const {
         return "\"" + str() + "\"";
     }
 
-    size_type       size() const {
+    size_type size() const {
         return last - first;
     }
 
-    size_type       length() const {
+    size_type length() const {
         return last - first;
     }
 
-    iterator        begin() {
+    iterator begin() {
         return base->begin() + first;
     }
 
-    const_iterator  begin() const {
+    const_iterator begin() const {
         return base->begin() + first;
     }
 
-    iterator        end() {
+    iterator end() {
         return base->begin() + last;
     }
 
-    const_iterator  end() const {
+    const_iterator end() const {
         return base->begin() + last;
     }
 
@@ -127,14 +117,14 @@ public:
         return (*base)[first + pos];
     }
 
-    element         operator[](size_type pos) {
+    element operator[](size_type pos) {
         return (*base)[first + pos];
     }
 
     // `str` に含まれる文字が(LightString内で)最初に出現する位置を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       find_first_of(const filter_type& filter, size_type pos = 0) const {
+    size_type find_first_of(const filter_type &filter, size_type pos = 0) const {
         size_type d = length();
         if (pos >= d) {
             return npos;
@@ -150,7 +140,7 @@ public:
     // `str` に含まれる文字が(LightString内で)最後に出現する位置を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       find_last_of(const filter_type& filter, size_type pos = 0) const {
+    size_type find_last_of(const filter_type &filter, size_type pos = 0) const {
         size_type d = length();
         if (pos >= d) {
             return npos;
@@ -167,7 +157,7 @@ public:
     // `str` に含まれない文字が(LightString内で)最初に出現する位置を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       find_first_not_of(const filter_type& filter, size_type pos = 0) const {
+    size_type find_first_not_of(const filter_type &filter, size_type pos = 0) const {
         size_type d = length();
         if (pos >= d) {
             return npos;
@@ -186,7 +176,7 @@ public:
     // `str` に含まれる文字が(LightString内で)最後に出現する位置を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       find_last_not_of(const filter_type& filter, size_type pos = 0) const {
+    size_type find_last_not_of(const filter_type &filter, size_type pos = 0) const {
         size_type d = length();
         if (pos >= d) {
             return npos;
@@ -206,10 +196,11 @@ public:
     // `str`が最初に出現する位置(= 先頭文字のインデックス)を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       find(const string_class& str, size_type pos = 0) const {
+    size_type find(const string_class &str, size_type pos = 0) const {
         for (size_type i = pos; i + str.size() <= size(); ++i) {
             size_type j = 0;
-            for (; j < str.size() && (*this)[i + j] == str[j]; ++j);
+            for (; j < str.size() && (*this)[i + j] == str[j]; ++j)
+                ;
             if (j == str.size()) {
                 return i;
             }
@@ -220,14 +211,16 @@ public:
     // `str`が最後に出現する位置(= 先頭文字のインデックス)を返す
     // `pos`が指定された場合, 位置`pos`以降のみを検索する
     // 位置は参照先文字列ではなく LightString 先頭からの相対位置
-    size_type       rfind(const string_class& str, size_type pos = 0) const {
+    size_type rfind(const string_class &str, size_type pos = 0) const {
         for (size_type i = size() - str.size(); pos <= i; --i) {
             size_type j = 0;
-            for (; j < str.size() && (*this)[i + j] == str[j]; ++j);
+            for (; j < str.size() && (*this)[i + j] == str[j]; ++j) {}
             if (j == str.size()) {
                 return i;
             }
-            if (pos == i) { break; }
+            if (pos == i) {
+                break;
+            }
         }
         return npos;
     }
@@ -242,7 +235,7 @@ public:
         if (n == std::string::npos) {
             return LightString(*this, pos, size());
         }
-        size_type   rlen = size() - pos;
+        size_type rlen = size() - pos;
         if (n < rlen) { // pos + n < size()
             rlen = n;
         }
@@ -252,7 +245,7 @@ public:
     // 「`pos`以降で最初に`filter`にマッチしなくなる位置」の直前までを参照する LightString を生成して返す
     // `pos`以前の部分も含まれることに注意.
     // ※ substr(0, find_first_not_of(filter, pos)) と*ほぼ*等価
-    LightString substr_while(const filter_type& filter, size_type pos = 0) const {
+    LightString substr_while(const filter_type &filter, size_type pos = 0) const {
         size_type n = find_first_not_of(filter, pos);
         if (n == npos) {
             return substr(pos);
@@ -263,7 +256,7 @@ public:
 
     // 「`pos`以降で最初に`filter`にマッチしなくなる位置」から後の部分を参照する LightString を生成して返す
     // ※ substr(find_first_not_of(filter, pos)) と等価
-    LightString substr_after(const filter_type& filter, size_type pos = 0) const {
+    LightString substr_after(const filter_type &filter, size_type pos = 0) const {
         size_type n = find_first_not_of(filter, pos);
         return substr(n);
     }
@@ -271,7 +264,7 @@ public:
     // 「`pos`以降で最初に`filter`にマッチする位置」の直前までを参照する LightString を生成して返す
     // `pos`以前の部分も含まれることに注意.
     // ※ substr(0, find_first_of(filter, pos)) と*ほぼ*等価
-    LightString substr_before(const filter_type& filter, size_type pos = 0) const {
+    LightString substr_before(const filter_type &filter, size_type pos = 0) const {
         size_type n = find_first_of(filter, pos);
         if (n == npos) {
             return substr(pos);
@@ -282,16 +275,16 @@ public:
 
     // 「`pos`以降で最初に`filter`にマッチする位置」から後の部分を参照する LightString を生成して返す
     // ※ substr(find_first_of(filter, pos)) と等価
-    LightString substr_from(const filter_type& filter, size_type pos = 0) const {
+    LightString substr_from(const filter_type &filter, size_type pos = 0) const {
         size_type n = find_first_of(filter, pos);
         return substr(n);
     }
 
-    std::vector<LightString>    split(const filter_type& filter) const {
-        std::vector<LightString>    rv;
+    std::vector<LightString> split(const filter_type &filter) const {
+        std::vector<LightString> rv;
         size_type word_from = 0;
-        size_type word_to = 0;
-        bool prev_is_sp = true;
+        size_type word_to   = 0;
+        bool prev_is_sp     = true;
         for (size_type i = 0; i <= size(); ++i) {
             if (i == size() || filter.includes((*this)[i])) {
                 word_to = i;
@@ -312,7 +305,7 @@ public:
     }
 
     // 文字集合`fil`内の文字を左側について切り落とした新たなLightStringを返す
-    LightString ltrim(const filter_type& fil) const {
+    LightString ltrim(const filter_type &fil) const {
         size_type first = find_first_not_of(fil);
         if (first == npos) {
             return LightString(*this, size(), size());
@@ -322,7 +315,7 @@ public:
     }
 
     // 文字集合`fil`内の文字を右側について切り落とした新たなLightStringを返す
-    LightString rtrim(const filter_type& fil) const {
+    LightString rtrim(const filter_type &fil) const {
         size_type last = find_last_not_of(fil);
         if (last == npos) {
             return LightString(*this, 0, 0);
@@ -332,17 +325,17 @@ public:
     }
 
     // 文字集合`fil`内の文字を左右から切り落とした新たなLightStringを返す
-    LightString trim(const filter_type& fil) const {
+    LightString trim(const filter_type &fil) const {
         return ltrim(fil).rtrim(fil);
     }
 };
 
 namespace HTTP {
-    typedef LightString<char_type>  light_string;
+typedef LightString<char_type> light_string;
 }
 
 template <class T>
-std::ostream&   operator<<(std::ostream& out, const LightString<T>& ls) {
+std::ostream &operator<<(std::ostream &out, const LightString<T> &ls) {
     return out << ls.str();
 }
 

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -1,30 +1,29 @@
 #include "http.hpp"
 
-const HTTP::t_version   HTTP::DEFAULT_HTTP_VERSION = V_1_1;
-
+const HTTP::t_version HTTP::DEFAULT_HTTP_VERSION = V_1_1;
 
 // アルファベット・小文字
-const HTTP::byte_string HTTP::Charset::alpha_low    = "abcdefghijklmnopqrstuvwxyz";
+const HTTP::byte_string HTTP::Charset::alpha_low = "abcdefghijklmnopqrstuvwxyz";
 // アルファベット・大文字
-const HTTP::byte_string HTTP::Charset::alpha_up     = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const HTTP::byte_string HTTP::Charset::alpha_up = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 // アルファベット
-const HTTP::byte_string HTTP::Charset::alpha        = alpha_low + alpha_up;
+const HTTP::byte_string HTTP::Charset::alpha = alpha_low + alpha_up;
 // 数字
-const HTTP::byte_string HTTP::Charset::digit        = "0123456789";
+const HTTP::byte_string HTTP::Charset::digit = "0123456789";
 // 16進数における数字
-const HTTP::byte_string HTTP::Charset::hexdig       = digit + "abcdef" + "ABCDEF";
+const HTTP::byte_string HTTP::Charset::hexdig = digit + "abcdef" + "ABCDEF";
 // HTTPにおける非予約文字
-const HTTP::byte_string HTTP::Charset::unreserved   = alpha + digit + "-._~";
-const HTTP::byte_string HTTP::Charset::gen_delims   = ":/?#[]@";
-const HTTP::byte_string HTTP::Charset::sub_delims   = "!$&'()*+.;=";
+const HTTP::byte_string HTTP::Charset::unreserved = alpha + digit + "-._~";
+const HTTP::byte_string HTTP::Charset::gen_delims = ":/?#[]@";
+const HTTP::byte_string HTTP::Charset::sub_delims = "!$&'()*+.;=";
 // token 構成文字
 // 空白, ":", ";", "/", "@", "?" を含まない.
 // ".", "&" は含む.
-const HTTP::byte_string HTTP::Charset::tchar        = alpha + digit + "!#$%&'*+-.^_`|~";
-const HTTP::byte_string HTTP::Charset::sp           = " ";
-const HTTP::byte_string HTTP::Charset::ws           = " \t";
-const HTTP::byte_string HTTP::Charset::crlf         = "\r\n";
-const HTTP::byte_string HTTP::Charset::lf           = "\n";
+const HTTP::byte_string HTTP::Charset::tchar = alpha + digit + "!#$%&'*+-.^_`|~";
+const HTTP::byte_string HTTP::Charset::sp    = " ";
+const HTTP::byte_string HTTP::Charset::ws    = " \t";
+const HTTP::byte_string HTTP::Charset::crlf  = "\r\n";
+const HTTP::byte_string HTTP::Charset::lf    = "\n";
 
 // parameter      = token "=" ( token / quoted-string )
 // quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
@@ -33,7 +32,6 @@ const HTTP::byte_string HTTP::Charset::lf           = "\n";
 //                ; HTAB + 表示可能文字, ただし "(ダブルクオート) と \(バッスラ) を除く
 // obs-text       = %x80-FF ; extended ASCII
 // quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
-
 
 const HTTP::byte_string HTTP::version_str(HTTP::t_version version) {
     switch (version) {

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -1,0 +1,82 @@
+#include "http.hpp"
+
+const HTTP::t_version   HTTP::DEFAULT_HTTP_VERSION = V_1_1;
+
+
+// アルファベット・小文字
+const HTTP::byte_string HTTP::Charset::alpha_low    = "abcdefghijklmnopqrstuvwxyz";
+// アルファベット・大文字
+const HTTP::byte_string HTTP::Charset::alpha_up     = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+// アルファベット
+const HTTP::byte_string HTTP::Charset::alpha        = alpha_low + alpha_up;
+// 数字
+const HTTP::byte_string HTTP::Charset::digit        = "0123456789";
+// 16進数における数字
+const HTTP::byte_string HTTP::Charset::hexdig       = digit + "abcdef" + "ABCDEF";
+// HTTPにおける非予約文字
+const HTTP::byte_string HTTP::Charset::unreserved   = alpha + digit + "-._~";
+const HTTP::byte_string HTTP::Charset::gen_delims   = ":/?#[]@";
+const HTTP::byte_string HTTP::Charset::sub_delims   = "!$&'()*+.;=";
+// token 構成文字
+// 空白, ":", ";", "/", "@", "?" を含まない.
+// ".", "&" は含む.
+const HTTP::byte_string HTTP::Charset::tchar        = alpha + digit + "!#$%&'*+-.^_`|~";
+const HTTP::byte_string HTTP::Charset::sp           = " ";
+const HTTP::byte_string HTTP::Charset::ws           = " \t";
+const HTTP::byte_string HTTP::Charset::crlf         = "\r\n";
+const HTTP::byte_string HTTP::Charset::lf           = "\n";
+
+// parameter      = token "=" ( token / quoted-string )
+// quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+// qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+//                ;               !     #-[        ]-~
+//                ; HTAB + 表示可能文字, ただし "(ダブルクオート) と \(バッスラ) を除く
+// obs-text       = %x80-FF ; extended ASCII
+// quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
+
+
+const HTTP::byte_string HTTP::version_str(HTTP::t_version version) {
+    switch (version) {
+        case V_0_9:
+            return "HTTP/0.9";
+        case V_1_0:
+            return "HTTP/1.0";
+        case V_1_1:
+            return "HTTP/1.1";
+        default:
+            return "";
+    }
+}
+
+const HTTP::byte_string HTTP::reason(HTTP::t_status status) {
+    switch (status) {
+        case HTTP::STATUS_OK:
+            return "OK";
+        case HTTP::STATUS_FOUND:
+            return "Found";
+        case HTTP::STATUS_BAD_REQUEST:
+            return "Bad Request";
+        case HTTP::STATUS_UNAUTHORIZED:
+            return "Unauthorized";
+        case HTTP::STATUS_FORBIDDEN:
+            return "Forbidden";
+        case HTTP::STATUS_NOT_FOUND:
+            return "Not Found";
+        case HTTP::STATUS_METHOD_NOT_ALLOWED:
+            return "Method Not Allowed";
+        case HTTP::STATUS_IM_A_TEAPOT:
+            return "I'm a teapot";
+        case HTTP::STATUS_INTERNAL_SERVER_ERROR:
+            return "Internal Server Error";
+        case HTTP::STATUS_NOT_IMPLEMENTED:
+            return "Not Implemented";
+        case HTTP::STATUS_BAD_GATEWAY:
+            return "Bad Gateway";
+        case HTTP::STATUS_SERVICE_UNAVAILABLE:
+            return "Service Unavailable";
+        case HTTP::STATUS_VERSION_NOT_SUPPORTED:
+            return "HTTP Version Not Supported";
+        default:
+            return "";
+    }
+}

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -1,0 +1,103 @@
+#ifndef HTTP_HPP
+# define HTTP_HPP
+# include <iostream>
+# include <string>
+# include <map>
+# include "test_common.hpp"
+
+// 全体で共通して使うenum, 型, 定数, フリー関数など
+
+namespace HTTP {
+    // ステータスコード
+    enum t_status {
+        STATUS_OK                       = 200,
+
+        STATUS_FOUND                    = 302,
+
+        STATUS_BAD_REQUEST              = 400,
+        STATUS_UNAUTHORIZED             = 401,
+        STATUS_FORBIDDEN                = 403,
+        STATUS_NOT_FOUND                = 404,
+        STATUS_METHOD_NOT_ALLOWED       = 405,
+        STATUS_URI_TOO_LONG             = 414,
+        STATUS_IM_A_TEAPOT              = 418,
+
+        STATUS_INTERNAL_SERVER_ERROR    = 500,
+        STATUS_NOT_IMPLEMENTED          = 501,
+        STATUS_BAD_GATEWAY              = 502,
+        STATUS_SERVICE_UNAVAILABLE      = 503,
+        STATUS_VERSION_NOT_SUPPORTED    = 505,
+
+        STATUS_DUMMY = 0
+    };
+
+    // リクエストメソッド
+    enum t_method {
+        METHOD_UNKNOWN,
+
+        METHOD_GET,
+        METHOD_POST,
+        METHOD_DELETE,
+
+        METHOD_ERROR
+    };
+
+    // HTTPバージョン
+    enum t_version {
+        V_UNKNOWN,
+
+        V_0_9,
+        V_1_0,
+        V_1_1,
+
+        V_ERROR
+    };
+
+    typedef char                            byte_type;
+    // バイト列
+    typedef std::basic_string<byte_type>    byte_string;
+    // ヘッダのキーの型
+    typedef byte_string                     header_key_type;
+    // ヘッダの値の型
+    typedef byte_string                     header_val_type;
+    // ヘッダのキー・値の組
+    typedef std::pair<header_key_type, header_val_type>
+                                            header_kvpair_type;
+    // ヘッダを格納する辞書
+    typedef std::map<header_key_type, header_val_type>
+                                            header_dict_type;
+
+    // サーバのデフォルトのHTTPバージョン
+    extern const t_version     DEFAULT_HTTP_VERSION;
+    const byte_string   version_str(t_version version);
+    const byte_string   reason(t_status status);
+
+    // 文字集合
+    namespace Charset {
+
+        // アルファベット・小文字
+        extern const byte_string alpha_low;
+        // アルファベット・大文字
+        extern const byte_string alpha_up;
+        // アルファベット
+        extern const byte_string alpha;
+        // 数字
+        extern const byte_string digit;
+        // 16進数における数字
+        extern const byte_string hexdig;
+        // HTTPにおける非予約文字
+        extern const byte_string unreserved;
+        extern const byte_string gen_delims;
+        extern const byte_string sub_delims;
+        // token 構成文字
+        // 空白, ":", ";", "/", "@", "?" を含まない.
+        // ".", "&" は含む.
+        extern const byte_string tchar;
+        extern const byte_string sp;
+        extern const byte_string ws;
+        extern const byte_string crlf;
+        extern const byte_string lf;
+    }
+}
+
+#endif

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -53,9 +53,10 @@ namespace HTTP {
         V_ERROR
     };
 
-    typedef char                            byte_type;
+    typedef char                            char_type;
+    typedef unsigned char                   byte_type;
     // バイト列
-    typedef std::basic_string<byte_type>    byte_string;
+    typedef std::basic_string<char_type>    byte_string;
     // ヘッダのキーの型
     typedef byte_string                     header_key_type;
     // ヘッダの値の型

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -1,104 +1,102 @@
 #ifndef HTTP_HPP
-# define HTTP_HPP
-# include <iostream>
-# include <string>
-# include <map>
-# include "test_common.hpp"
+#define HTTP_HPP
+#include "test_common.hpp"
+#include <iostream>
+#include <map>
+#include <string>
 
 // 全体で共通して使うenum, 型, 定数, フリー関数など
 
 namespace HTTP {
-    // ステータスコード
-    enum t_status {
-        STATUS_OK                       = 200,
+// ステータスコード
+enum t_status {
+    STATUS_OK = 200,
 
-        STATUS_FOUND                    = 302,
+    STATUS_FOUND = 302,
 
-        STATUS_BAD_REQUEST              = 400,
-        STATUS_UNAUTHORIZED             = 401,
-        STATUS_FORBIDDEN                = 403,
-        STATUS_NOT_FOUND                = 404,
-        STATUS_METHOD_NOT_ALLOWED       = 405,
-        STATUS_URI_TOO_LONG             = 414,
-        STATUS_IM_A_TEAPOT              = 418,
+    STATUS_BAD_REQUEST        = 400,
+    STATUS_UNAUTHORIZED       = 401,
+    STATUS_FORBIDDEN          = 403,
+    STATUS_NOT_FOUND          = 404,
+    STATUS_METHOD_NOT_ALLOWED = 405,
+    STATUS_URI_TOO_LONG       = 414,
+    STATUS_IM_A_TEAPOT        = 418,
 
-        STATUS_INTERNAL_SERVER_ERROR    = 500,
-        STATUS_NOT_IMPLEMENTED          = 501,
-        STATUS_BAD_GATEWAY              = 502,
-        STATUS_SERVICE_UNAVAILABLE      = 503,
-        STATUS_VERSION_NOT_SUPPORTED    = 505,
+    STATUS_INTERNAL_SERVER_ERROR = 500,
+    STATUS_NOT_IMPLEMENTED       = 501,
+    STATUS_BAD_GATEWAY           = 502,
+    STATUS_SERVICE_UNAVAILABLE   = 503,
+    STATUS_VERSION_NOT_SUPPORTED = 505,
 
-        STATUS_DUMMY = 0
-    };
+    STATUS_DUMMY = 0
+};
 
-    // リクエストメソッド
-    enum t_method {
-        METHOD_UNKNOWN,
+// リクエストメソッド
+enum t_method {
+    METHOD_UNKNOWN,
 
-        METHOD_GET,
-        METHOD_POST,
-        METHOD_DELETE,
+    METHOD_GET,
+    METHOD_POST,
+    METHOD_DELETE,
 
-        METHOD_ERROR
-    };
+    METHOD_ERROR
+};
 
-    // HTTPバージョン
-    enum t_version {
-        V_UNKNOWN,
+// HTTPバージョン
+enum t_version {
+    V_UNKNOWN,
 
-        V_0_9,
-        V_1_0,
-        V_1_1,
+    V_0_9,
+    V_1_0,
+    V_1_1,
 
-        V_ERROR
-    };
+    V_ERROR
+};
 
-    typedef char                            char_type;
-    typedef unsigned char                   byte_type;
-    // バイト列
-    typedef std::basic_string<char_type>    byte_string;
-    // ヘッダのキーの型
-    typedef byte_string                     header_key_type;
-    // ヘッダの値の型
-    typedef byte_string                     header_val_type;
-    // ヘッダのキー・値の組
-    typedef std::pair<header_key_type, header_val_type>
-                                            header_kvpair_type;
-    // ヘッダを格納する辞書
-    typedef std::map<header_key_type, header_val_type>
-                                            header_dict_type;
+typedef char char_type;
+typedef unsigned char byte_type;
+// バイト列
+typedef std::basic_string<char_type> byte_string;
+// ヘッダのキーの型
+typedef byte_string header_key_type;
+// ヘッダの値の型
+typedef byte_string header_val_type;
+// ヘッダのキー・値の組
+typedef std::pair<header_key_type, header_val_type> header_kvpair_type;
+// ヘッダを格納する辞書
+typedef std::map<header_key_type, header_val_type> header_dict_type;
 
-    // サーバのデフォルトのHTTPバージョン
-    extern const t_version     DEFAULT_HTTP_VERSION;
-    const byte_string   version_str(t_version version);
-    const byte_string   reason(t_status status);
+// サーバのデフォルトのHTTPバージョン
+extern const t_version DEFAULT_HTTP_VERSION;
+const byte_string version_str(t_version version);
+const byte_string reason(t_status status);
 
-    // 文字集合
-    namespace Charset {
+// 文字集合
+namespace Charset {
 
-        // アルファベット・小文字
-        extern const byte_string alpha_low;
-        // アルファベット・大文字
-        extern const byte_string alpha_up;
-        // アルファベット
-        extern const byte_string alpha;
-        // 数字
-        extern const byte_string digit;
-        // 16進数における数字
-        extern const byte_string hexdig;
-        // HTTPにおける非予約文字
-        extern const byte_string unreserved;
-        extern const byte_string gen_delims;
-        extern const byte_string sub_delims;
-        // token 構成文字
-        // 空白, ":", ";", "/", "@", "?" を含まない.
-        // ".", "&" は含む.
-        extern const byte_string tchar;
-        extern const byte_string sp;
-        extern const byte_string ws;
-        extern const byte_string crlf;
-        extern const byte_string lf;
-    }
-}
+// アルファベット・小文字
+extern const byte_string alpha_low;
+// アルファベット・大文字
+extern const byte_string alpha_up;
+// アルファベット
+extern const byte_string alpha;
+// 数字
+extern const byte_string digit;
+// 16進数における数字
+extern const byte_string hexdig;
+// HTTPにおける非予約文字
+extern const byte_string unreserved;
+extern const byte_string gen_delims;
+extern const byte_string sub_delims;
+// token 構成文字
+// 空白, ":", ";", "/", "@", "?" を含まない.
+// ".", "&" は含む.
+extern const byte_string tchar;
+extern const byte_string sp;
+extern const byte_string ws;
+extern const byte_string crlf;
+extern const byte_string lf;
+} // namespace Charset
+} // namespace HTTP
 
 #endif

--- a/src/utils/test_common.cpp
+++ b/src/utils/test_common.cpp
@@ -1,0 +1,17 @@
+#include "test_common.hpp"
+
+std::ostream&   debug_out(
+    const char *filename,
+    const int linenumber,
+    const char *func
+) {
+    return (std::cout << "[" << filename << ":" << linenumber << " " << func << "] ");
+}
+
+std::ostream&   debug_err(
+    const char *filename,
+    const int linenumber,
+    const char *func
+) {
+    return (std::cerr << "[" << filename << ":" << linenumber << " " << func << "] ");
+}

--- a/src/utils/test_common.cpp
+++ b/src/utils/test_common.cpp
@@ -1,17 +1,9 @@
 #include "test_common.hpp"
 
-std::ostream&   debug_out(
-    const char *filename,
-    const int linenumber,
-    const char *func
-) {
+std::ostream &debug_out(const char *filename, const int linenumber, const char *func) {
     return (std::cout << "[" << filename << ":" << linenumber << " " << func << "] ");
 }
 
-std::ostream&   debug_err(
-    const char *filename,
-    const int linenumber,
-    const char *func
-) {
+std::ostream &debug_err(const char *filename, const int linenumber, const char *func) {
     return (std::cerr << "[" << filename << ":" << linenumber << " " << func << "] ");
 }

--- a/src/utils/test_common.hpp
+++ b/src/utils/test_common.hpp
@@ -4,13 +4,17 @@
 # include <iostream>
 # include <string>
 # include <cstdlib>
-// TODO: この辺レギュレーション的に使えないので注意
-# define DSOUT() debug_out(__FILE__, __LINE__, __func__)
-# define DOUT()  debug_err(__FILE__, __LINE__, __func__)
-# define DXOUT(expr) do { debug_out(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
-# define DXERR(expr) do { debug_err(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
-// # define DXOUT(expr) ((void)0)
-
+# ifdef NDEBUG
+#  define DXOUT(expr) ((void)0)
+#  define DXERR(expr) ((void)0)
+# else
+#  define DXOUT(expr) do { debug_out(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
+#  define DXERR(expr) do { debug_err(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
+# endif
+// 変数の中身の表示
+# define VOUT(expr) DXOUT(#expr ": " << expr)
+// 変数の中身の表示(クオート付き)
+# define QVOUT(expr) DXOUT(#expr ": \"" << expr << "\"")
 
 std::ostream&   debug_out(
     const char *filename,

--- a/src/utils/test_common.hpp
+++ b/src/utils/test_common.hpp
@@ -1,0 +1,27 @@
+#ifndef TEST_COMMON_HPP
+# define TEST_COMMON_HPP
+
+# include <iostream>
+# include <string>
+# include <cstdlib>
+// TODO: この辺レギュレーション的に使えないので注意
+# define DSOUT() debug_out(__FILE__, __LINE__, __func__)
+# define DOUT()  debug_err(__FILE__, __LINE__, __func__)
+# define DXOUT(expr) do { debug_out(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
+# define DXERR(expr) do { debug_err(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
+// # define DXOUT(expr) ((void)0)
+
+
+std::ostream&   debug_out(
+    const char *filename,
+    const int linenumber,
+    const char *func
+);
+
+std::ostream&   debug_err(
+    const char *filename,
+    const int linenumber,
+    const char *func
+);
+
+#endif

--- a/src/utils/test_common.hpp
+++ b/src/utils/test_common.hpp
@@ -1,31 +1,29 @@
 #ifndef TEST_COMMON_HPP
-# define TEST_COMMON_HPP
+#define TEST_COMMON_HPP
 
-# include <iostream>
-# include <string>
-# include <cstdlib>
-# ifdef NDEBUG
-#  define DXOUT(expr) ((void)0)
-#  define DXERR(expr) ((void)0)
-# else
-#  define DXOUT(expr) do { debug_out(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
-#  define DXERR(expr) do { debug_err(__FILE__, __LINE__, __func__) << expr << std::endl; } while(0)
-# endif
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#ifdef NDEBUG
+#define DXOUT(expr) ((void)0)
+#define DXERR(expr) ((void)0)
+#else
+#define DXOUT(expr)                                                                                                    \
+    do {                                                                                                               \
+        debug_out(__FILE__, __LINE__, __func__) << expr << std::endl;                                                  \
+    } while (0)
+#define DXERR(expr)                                                                                                    \
+    do {                                                                                                               \
+        debug_err(__FILE__, __LINE__, __func__) << expr << std::endl;                                                  \
+    } while (0)
+#endif
 // 変数の中身の表示
-# define VOUT(expr) DXOUT(#expr ": " << expr)
+#define VOUT(expr) DXOUT(#expr ": " << expr)
 // 変数の中身の表示(クオート付き)
-# define QVOUT(expr) DXOUT(#expr ": \"" << expr << "\"")
+#define QVOUT(expr) DXOUT(#expr ": \"" << expr << "\"")
 
-std::ostream&   debug_out(
-    const char *filename,
-    const int linenumber,
-    const char *func
-);
+std::ostream &debug_out(const char *filename, const int linenumber, const char *func);
 
-std::ostream&   debug_err(
-    const char *filename,
-    const int linenumber,
-    const char *func
-);
+std::ostream &debug_err(const char *filename, const int linenumber, const char *func);
 
 #endif


### PR DESCRIPTION
- `http.hpp, http.cpp`のもろもろ
  - 定数, 型定義, enumなど。
- `debug_out, debug_err`関数, `DXOUT, DXERR`マクロ
  - デバッグ用。
- `IndexRange`クラス
  - インデックスの「範囲」を表す`std::pair`の変種。
- `CharFilter`クラス
  - 「文字集合」によるマッチングを簡単に行うための文字集合クラス。
- `LightString<T>`クラス
  - 別の文字列の一部分だけを参照し, それをあたかも独立した文字列かのように色々するためのクラス。