### PR TITLE
fixes #20 clang-formatが適用されない

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBinaryOperators: "BOS_None"
+BreakBeforeBinaryOperators: "All"
 BreakBeforeBraces: "Attach"
 BreakConstructorInitializersBeforeComma: true
 ColumnLimit: 120


### PR DESCRIPTION
resolves #20 
行数が長い場合に演算子を左寄せにフォーマットするように修正した。