### PR TITLE
fixes #49 clang-formatによって型宣言の山括弧のスペースが埋められてコンパイルできない

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,3 +16,4 @@ ColumnLimit: 120
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 IndentCaseLabels: true
+Standard: "Cpp03"


### PR DESCRIPTION
#### 概要
resolves #49 
clang-formatによって山括弧が重なるときにスペースを開けるように修正した。