### PR TITLE
bugfix: static定数が初期化されない

### DIFF
--- a/src/utils/CharFilter.cpp
+++ b/src/utils/CharFilter.cpp
@@ -163,24 +163,24 @@ std::ostream &operator<<(std::ostream &ost, const HTTP::CharFilter &f) {
     return ost << "(" << f.size() << "):[" << f.str() << "]";
 }
 
-const HTTP::CharFilter HTTP::CharFilter::alpha_low  = HTTP::Charset::alpha_low;
-const HTTP::CharFilter HTTP::CharFilter::alpha_up   = HTTP::Charset::alpha_up;
-const HTTP::CharFilter HTTP::CharFilter::alpha      = HTTP::Charset::alpha;
-const HTTP::CharFilter HTTP::CharFilter::digit      = HTTP::Charset::digit;
-const HTTP::CharFilter HTTP::CharFilter::hexdig     = HTTP::Charset::hexdig;
-const HTTP::CharFilter HTTP::CharFilter::unreserved = HTTP::Charset::unreserved;
-const HTTP::CharFilter HTTP::CharFilter::gen_delims = HTTP::Charset::gen_delims;
-const HTTP::CharFilter HTTP::CharFilter::sub_delims = HTTP::Charset::sub_delims;
-const HTTP::CharFilter HTTP::CharFilter::tchar      = HTTP::Charset::tchar;
-const HTTP::CharFilter HTTP::CharFilter::sp         = HTTP::Charset::sp;
+const HTTP::CharFilter HTTP::CharFilter::alpha_low  = HTTP::strfy("abcdefghijklmnopqrstuvwxyz");
+const HTTP::CharFilter HTTP::CharFilter::alpha_up   = HTTP::strfy("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+const HTTP::CharFilter HTTP::CharFilter::alpha      = alpha_low | alpha_up;
+const HTTP::CharFilter HTTP::CharFilter::digit      = HTTP::strfy("0123456789");
+const HTTP::CharFilter HTTP::CharFilter::hexdig     = digit | "abcdef" | "ABCDEF";
+const HTTP::CharFilter HTTP::CharFilter::unreserved = alpha | digit | "-._~";
+const HTTP::CharFilter HTTP::CharFilter::gen_delims = HTTP::strfy(":/?#[]@");
+const HTTP::CharFilter HTTP::CharFilter::sub_delims = HTTP::strfy("!$&'()*+.;=");
+const HTTP::CharFilter HTTP::CharFilter::tchar      = alpha | digit | "!#$%&'*+-.^_`|~";
+const HTTP::CharFilter HTTP::CharFilter::sp         = HTTP::strfy(" ");
 const HTTP::CharFilter HTTP::CharFilter::bad_sp     = HTTP::CharFilter::sp;
-const HTTP::CharFilter HTTP::CharFilter::ws         = HTTP::Charset::ws;
-const HTTP::CharFilter HTTP::CharFilter::crlf       = HTTP::Charset::crlf;
-const HTTP::CharFilter HTTP::CharFilter::cr         = "\r";
-const HTTP::CharFilter HTTP::CharFilter::lf         = HTTP::Charset::lf;
-const HTTP::CharFilter HTTP::CharFilter::htab       = "\t";
-const HTTP::CharFilter HTTP::CharFilter::dquote     = "\"";
-const HTTP::CharFilter HTTP::CharFilter::bslash     = "\\";
+const HTTP::CharFilter HTTP::CharFilter::ws         = HTTP::strfy(" \t");
+const HTTP::CharFilter HTTP::CharFilter::crlf       = HTTP::strfy("\r\n");
+const HTTP::CharFilter HTTP::CharFilter::cr         = HTTP::strfy("\r");
+const HTTP::CharFilter HTTP::CharFilter::lf         = HTTP::strfy("\n");
+const HTTP::CharFilter HTTP::CharFilter::htab       = HTTP::strfy("\t");
+const HTTP::CharFilter HTTP::CharFilter::dquote     = HTTP::strfy("\"");
+const HTTP::CharFilter HTTP::CharFilter::bslash     = HTTP::strfy("\\");
 const HTTP::CharFilter HTTP::CharFilter::obs_text   = HTTP::CharFilter(0x80, 0xff);
 const HTTP::CharFilter HTTP::CharFilter::vchar      = HTTP::CharFilter(0x21, 0x7e);
 const HTTP::CharFilter HTTP::CharFilter::qdtext

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -2,37 +2,6 @@
 
 const HTTP::t_version HTTP::DEFAULT_HTTP_VERSION = V_1_1;
 
-// アルファベット・小文字
-const HTTP::byte_string HTTP::Charset::alpha_low = HTTP::strfy("abcdefghijklmnopqrstuvwxyz");
-// アルファベット・大文字
-const HTTP::byte_string HTTP::Charset::alpha_up = HTTP::strfy("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
-// アルファベット
-const HTTP::byte_string HTTP::Charset::alpha = alpha_low + alpha_up;
-// 数字
-const HTTP::byte_string HTTP::Charset::digit = HTTP::strfy("0123456789");
-// 16進数における数字
-const HTTP::byte_string HTTP::Charset::hexdig = digit + "abcdef" + "ABCDEF";
-// HTTPにおける非予約文字
-const HTTP::byte_string HTTP::Charset::unreserved = alpha + digit + "-._~";
-const HTTP::byte_string HTTP::Charset::gen_delims = HTTP::strfy(":/?#[]@");
-const HTTP::byte_string HTTP::Charset::sub_delims = HTTP::strfy("!$&'()*+.;=");
-// token 構成文字
-// 空白, ":", ";", "/", "@", "?" を含まない.
-// ".", "&" は含む.
-const HTTP::byte_string HTTP::Charset::tchar = alpha + digit + "!#$%&'*+-.^_`|~";
-const HTTP::byte_string HTTP::Charset::sp    = HTTP::strfy(" ");
-const HTTP::byte_string HTTP::Charset::ws    = HTTP::strfy(" \t");
-const HTTP::byte_string HTTP::Charset::crlf  = HTTP::strfy("\r\n");
-const HTTP::byte_string HTTP::Charset::lf    = HTTP::strfy("\n");
-
-// parameter      = token "=" ( token / quoted-string )
-// quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
-// qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
-//                ;               !     #-[        ]-~
-//                ; HTAB + 表示可能文字, ただし "(ダブルクオート) と \(バッスラ) を除く
-// obs-text       = %x80-FF ; extended ASCII
-// quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
-
 const HTTP::byte_string HTTP::version_str(HTTP::t_version version) {
     switch (version) {
         case V_0_9:

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -76,33 +76,6 @@ extern const t_version DEFAULT_HTTP_VERSION;
 const byte_string version_str(t_version version);
 const byte_string reason(t_status status);
 
-// 文字集合
-namespace Charset {
-
-// アルファベット・小文字
-extern const byte_string alpha_low;
-// アルファベット・大文字
-extern const byte_string alpha_up;
-// アルファベット
-extern const byte_string alpha;
-// 数字
-extern const byte_string digit;
-// 16進数における数字
-extern const byte_string hexdig;
-// HTTPにおける非予約文字
-extern const byte_string unreserved;
-extern const byte_string gen_delims;
-extern const byte_string sub_delims;
-// token 構成文字
-// 空白, ":", ";", "/", "@", "?" を含まない.
-// ".", "&" は含む.
-extern const byte_string tchar;
-extern const byte_string sp;
-extern const byte_string ws;
-extern const byte_string crlf;
-extern const byte_string lf;
-} // namespace Charset
-
 // 文字列をbyte_stringに変換する
 byte_string strfy(const char_string &str);
 // byte_stringを文字列に変換する


### PR DESCRIPTION
`HTTP::Charset`に定義されていた`static`定数の初期化がされていないため、HTTPメッセージのパースに失敗していた。
`HTTP::Charset`の定数は`HTTP::CharFilter`の定数を初期化するためだけの存在と化していたので、`HTTP::Charset`の定数を廃止した。