### PR TITLE
bugfix: host: ヘッダがポート付きの場合正しくパースできない

### DIFF
--- a/src/communication/ValidatorHTTP.cpp
+++ b/src/communication/ValidatorHTTP.cpp
@@ -5,7 +5,7 @@ bool HTTP::Validator::is_valid_header_host(const light_string &str) {
     // host = uri-host [ ":" port ]
 
     byte_string::size_type ket = str.find_last_of("]");
-    byte_string::size_type sep = str.find_last_of(":", ket);
+    byte_string::size_type sep = str.find_last_of(":", ket == npos ? 0 : ket);
     if (sep != npos && 0 < sep && str[sep - 1] != ':') {
         // ":"がある -> portとしての妥当性チェック
         if (!is_port(str.substr(sep + 1))) {


### PR DESCRIPTION
`ket`は、「`host:`に含まれる最後の`]`の場所」。
これより後ろにある`:`を探してホストとポート番号の区切りとみなしたいのだが、
`]`が見つからない、すなわち`ket == npos`の場合は`:`の探索開始位置が`npos`となってしまうため、
`:`を無視するようになっていた。