### PR TITLE
オブザーバはソケットライクにイベント種別を通知 & タイムアウトもnotifyで通知

### DIFF
--- a/src/communication/Channel.cpp
+++ b/src/communication/Channel.cpp
@@ -14,10 +14,14 @@ t_fd Channel::get_fd() const {
     return sock->get_fd();
 }
 
-void Channel::notify(IObserver &observer) {
+void Channel::notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch) {
+    (void)epoch;
     // Channelがnotifyを受ける
     // -> accept ready
     // -> Connectionを生成してread監視させる
+    if (cat != IObserver::OT_READ) {
+        return;
+    }
     try {
         for (;;) {
             SocketConnected *connected = sock->accept();
@@ -25,18 +29,13 @@ void Channel::notify(IObserver &observer) {
                 // acceptするものが残っていない場合 NULL が返ってくる
                 break;
             }
-            observer.reserve_set(new Connection(router_, connected), IObserver::OT_READ);
+            Connection *con = new Connection(router_, connected);
+            observer.reserve_hold(con);
+            observer.reserve_set(con, IObserver::OT_READ);
         }
     } catch (...) {
         DXOUT("[!!!!] failed to accept socket: fd: " << sock->get_fd());
     }
-}
-
-void Channel::timeout(IObserver &observer, t_time_epoch_ms epoch) {
-    // * DO NOTHING *
-    (void)observer;
-    (void)epoch;
-    // DXOUT("* DO NOTHING *: " << get_fd());
 }
 
 Channel::t_channel_id Channel::get_id() const {

--- a/src/communication/Channel.hpp
+++ b/src/communication/Channel.hpp
@@ -2,7 +2,7 @@
 #define CHANNEL_HPP
 #include "../interface/IObserver.hpp"
 #include "../interface/IRouter.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include "../socket/SocketListening.hpp"
 #include <map>
 #include <utility>
@@ -29,8 +29,7 @@ public:
     ~Channel();
 
     t_fd get_fd() const;
-    void notify(IObserver &observer);
-    void timeout(IObserver &observer, t_time_epoch_ms epoch);
+    void notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
 
     t_channel_id get_id() const;
 };

--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -46,6 +46,7 @@ void Connection::notify(IObserver &observer, IObserver::observation_category cat
         // タイムアウト処理
         DXOUT("timeout!!: " << get_fd());
         die(observer);
+        return;
     }
 
     const size_t read_buffer_size = RequestHTTP::MAX_REQLINE_END;

--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -36,7 +36,6 @@ t_fd Connection::get_fd() const {
 }
 
 void Connection::notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch) {
-    (void)cat;
     if (dying) {
         return;
     }

--- a/src/communication/Connection.hpp
+++ b/src/communication/Connection.hpp
@@ -2,7 +2,7 @@
 #define CONNECTION_HPP
 #include "../interface/IObserver.hpp"
 #include "../interface/IRouter.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include "../socket/SocketConnected.hpp"
 #include "RequestHTTP.hpp"
 #include "ResponseHTTP.hpp"
@@ -77,8 +77,7 @@ public:
     ~Connection();
 
     t_fd get_fd() const;
-    void notify(IObserver &observer);
-    void timeout(IObserver &observer, t_time_epoch_ms epoch);
+    void notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
 };
 
 #endif

--- a/src/event/Eventkqueueloop.cpp
+++ b/src/event/Eventkqueueloop.cpp
@@ -163,17 +163,10 @@ void EventKqueueLoop::update() {
         n++;
     }
     if (n > 0) {
-        std::cout << "[";
-        for (size_t i = 0; i < changelist.size(); ++i) {
-            std::cout << changelist[i].ident << " ";
-        }
-        std::cout << "]" << std::endl;
         errno     = 0;
         int count = kevent(kq, &*changelist.begin(), changelist.size(), NULL, 0, NULL);
         if (errno) {
-            VOUT(errno);
             QVOUT(strerror(errno));
-            DXOUT(changelist.size() << ", " << n << ", " << count);
         }
     }
 

--- a/src/event/Eventkqueueloop.cpp
+++ b/src/event/Eventkqueueloop.cpp
@@ -13,12 +13,12 @@ EventKqueueLoop::EventKqueueLoop() {
 }
 
 EventKqueueLoop::~EventKqueueLoop() {
-    for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
+    for (socket_map::iterator it = holding_map.begin(); it != holding_map.end(); ++it) {
         delete it->second;
     }
 }
 
-EventKqueueLoop::t_kfilter EventKqueueLoop::filter(t_observation_target t) {
+EventKqueueLoop::t_kfilter EventKqueueLoop::filter(observation_category t) {
     switch (t) {
         case OT_READ:
             return EVFILT_READ;
@@ -33,49 +33,68 @@ EventKqueueLoop::t_kfilter EventKqueueLoop::filter(t_observation_target t) {
     }
 }
 
+IObserver::observation_category EventKqueueLoop::filter_to_cat(t_kfilter f) {
+    switch (f) {
+        case EVFILT_READ:
+            return IObserver::OT_READ;
+        case EVFILT_WRITE:
+            return IObserver::OT_WRITE;
+        case EVFILT_EXCEPT:
+            return IObserver::OT_EXCEPTION;
+        default:
+            throw std::runtime_error("unexpected map_type");
+    }
+}
+
 void EventKqueueLoop::loop() {
     while (true) {
         update();
 
         int count = kevent(kq, NULL, 0, &*evlist.begin(), nev, NULL);
+        VOUT(count);
         if (count < 0) {
             throw std::runtime_error("kevent error");
         } else if (count == 0) {
             t_time_epoch_ms now = WSTime::get_epoch_ms();
             for (int i = 0; i < count; i++) {
                 int fd            = static_cast<int>(evlist[i].ident);
-                ISocketLike *sock = sockmap[fd];
-                sock->timeout(*this, now);
+                ISocketLike *sock = holding_map[fd];
+                sock->notify(*this, OT_TIMEOUT, now);
             }
         } else {
             for (int i = 0; i < count; i++) {
-                int fd            = static_cast<int>(evlist[i].ident);
-                ISocketLike *sock = sockmap[fd];
-                sock->notify(*this);
+                int fd                   = static_cast<int>(evlist[i].ident);
+                ISocketLike *sock        = holding_map[fd];
+                observation_category cat = filter_to_cat(evlist[i].filter);
+                sock->notify(*this, cat, 0);
             }
         }
     }
 }
 
-void EventKqueueLoop::reserve(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    t_socket_reservation pre = {socket, from, to};
+void EventKqueueLoop::reserve(ISocketLike *socket, observation_category cat, bool in) {
+    t_socket_reservation pre = {socket->get_fd(), socket, cat, in};
     upqueue.push_back(pre);
 }
 
+void EventKqueueLoop::reserve_hold(ISocketLike *socket) {
+    reserve(socket, OT_NONE, true);
+}
+
+void EventKqueueLoop::reserve_unhold(ISocketLike *socket) {
+    reserve(socket, OT_NONE, false);
+    DXOUT("reserved unhold: " << socket->get_fd());
+}
+
 // 次の kevent の前に, このソケットを監視対象から除外する
-// (その際ソケットはdeleteされる)
-void EventKqueueLoop::reserve_clear(ISocketLike *socket, t_observation_target from) {
-    reserve(socket, from, OT_NONE);
+void EventKqueueLoop::reserve_unset(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, false);
+    DXOUT("reserved unset: " << socket->get_fd() << " " << cat);
 }
 
 // 次の kevent の前に, このソケットを監視対象に追加する
-void EventKqueueLoop::reserve_set(ISocketLike *socket, t_observation_target to) {
-    reserve(socket, OT_NONE, to);
-}
-
-// 次の kevent の前に, このソケットの監視方法を変更する
-void EventKqueueLoop::reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    reserve(socket, from, to);
+void EventKqueueLoop::reserve_set(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, true);
 }
 
 void EventKqueueLoop::update() {
@@ -84,26 +103,88 @@ void EventKqueueLoop::update() {
     if (upqueue.empty()) {
         return;
     }
-    int n = 0;
-    for (update_queue::iterator it = upqueue.begin(); it != upqueue.end(); it++) {
-        t_kevent ke;
-        ISocketLike *sock = it->sock;
-        t_fd fd           = sock->get_fd();
-        if (it->to == OT_NONE) {
-            sockmap.erase(fd);
-            delete sock;
-        } else {
-            changelist.push_back(ke);
-            EV_SET(&*changelist.rbegin(), sock->get_fd(), filter(it->to), EV_ADD, 0, 0, NULL);
-            sockmap[fd] = sock;
-            n++;
+    // exec hold
+    for (update_queue::size_type i = 0; i < upqueue.size(); ++i) {
+        ISocketLike *sock = upqueue[i].sock;
+        t_fd fd           = upqueue[i].fd;
+        if (upqueue[i].cat == OT_NONE && upqueue[i].in) {
+            holding_map.insert(socket_map::value_type(fd, sock));
+            DXOUT("HOLDED: " << fd);
         }
     }
+
+    // exec set or unset
+    int n = 0;
+    for (update_queue::size_type i = 0; i < upqueue.size(); ++i) {
+        if (upqueue[i].cat == OT_NONE) {
+            continue;
+        }
+        t_fd fd                  = upqueue[i].fd;
+        bool in                  = upqueue[i].in;
+        observation_category cat = upqueue[i].cat;
+        t_kevent ke;
+        ISocketLike *sock = upqueue[i].sock;
+        switch (cat) {
+            case OT_READ: {
+                if (in) {
+                    read_map.insert(socket_map::value_type(fd, sock));
+                } else {
+                    read_map.erase(fd);
+                }
+                break;
+            }
+            case OT_WRITE: {
+                if (in) {
+                    write_map.insert(socket_map::value_type(fd, sock));
+                } else {
+                    write_map.erase(fd);
+                }
+                break;
+            }
+            case OT_EXCEPTION: {
+                if (upqueue[i].in) {
+                    exception_map.insert(socket_map::value_type(fd, sock));
+                } else {
+                    exception_map.erase(fd);
+                }
+                break;
+            }
+            default:
+                throw std::runtime_error("unexpected cat");
+        }
+        changelist.push_back(ke);
+        if (in) {
+            DXOUT("ADDING " << fd << " " << cat);
+            EV_SET(&*changelist.rbegin(), fd, filter(cat), EV_ADD, 0, 0, NULL);
+        } else if (!in) {
+            DXOUT("DELETING " << fd << " " << cat);
+            EV_SET(&*changelist.rbegin(), fd, filter(cat), EV_DISABLE, 0, 0, NULL);
+        }
+        n++;
+    }
     if (n > 0) {
+        std::cout << "[";
+        for (size_t i = 0; i < changelist.size(); ++i) {
+            std::cout << changelist[i].ident << " ";
+        }
+        std::cout << "]" << std::endl;
         errno     = 0;
         int count = kevent(kq, &*changelist.begin(), changelist.size(), NULL, 0, NULL);
         if (errno) {
-            DXOUT("errno: " << errno << ", " << changelist.size() << ", " << n << ", " << count);
+            VOUT(errno);
+            QVOUT(strerror(errno));
+            DXOUT(changelist.size() << ", " << n << ", " << count);
+        }
+    }
+
+    // exec unhold
+    for (update_queue::size_type i = 0; i < upqueue.size(); ++i) {
+        ISocketLike *sock = upqueue[i].sock;
+        t_fd fd           = upqueue[i].fd;
+        if (upqueue[i].cat == OT_NONE && !upqueue[i].in) {
+            holding_map.erase(fd);
+            delete sock;
+            DXOUT("UNHOLDED: " << fd);
         }
     }
     upqueue.clear();

--- a/src/event/Eventkqueueloop.hpp
+++ b/src/event/Eventkqueueloop.hpp
@@ -2,10 +2,11 @@
 #define EVENT_KQUEUE_LOOP_HPP
 
 #include "../interface/IObserver.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include <cerrno>
 #include <ctime>
 #include <map>
+#include <set>
 #include <sys/event.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -23,15 +24,19 @@ private:
     typedef short t_kfilter;
     typedef int t_kqueue;
 
-    socket_map sockmap;
+    socket_map read_map;
+    socket_map write_map;
+    socket_map exception_map;
     update_queue upqueue;
+    socket_map holding_map;
     event_list evlist;
     static const int nev;
     t_kqueue kq;
 
-    t_kfilter filter(t_observation_target t);
+    t_kfilter filter(observation_category t);
+    observation_category filter_to_cat(t_kfilter f);
 
-    void reserve(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void reserve(ISocketLike *socket, observation_category cat, bool in);
     void update();
 
 public:
@@ -39,9 +44,10 @@ public:
     ~EventKqueueLoop();
 
     void loop();
-    void reserve_clear(ISocketLike *socket, t_observation_target from);
-    void reserve_set(ISocketLike *socket, t_observation_target to);
-    void reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void reserve_hold(ISocketLike *socket);
+    void reserve_unhold(ISocketLike *socket);
+    void reserve_unset(ISocketLike *socket, observation_category cat);
+    void reserve_set(ISocketLike *socket, observation_category to);
 };
 
 #endif

--- a/src/event/Eventpollloop.cpp
+++ b/src/event/Eventpollloop.cpp
@@ -4,9 +4,12 @@
 EventPollLoop::EventPollLoop() : nfds(0) {}
 
 EventPollLoop::~EventPollLoop() {
-    for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
+    DXOUT("destroying... " << sockmap.size());
+    for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); ++it) {
+        DXOUT("delete " << it->second);
         delete it->second;
     }
+    DXOUT("destroyed");
 }
 
 // イベントループ
@@ -20,54 +23,62 @@ void EventPollLoop::loop() {
             throw std::runtime_error("poll error");
         } else if (count == 0) {
             t_time_epoch_ms now = WSTime::get_epoch_ms();
-            for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
+            for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); ++it) {
                 size_t i = indexmap[it->first];
                 if (fds[i].fd >= 0) {
-                    it->second->timeout(*this, now);
+                    it->second->notify(*this, OT_TIMEOUT, now);
                 }
             }
         } else {
-            for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
+            for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); ++it) {
                 size_t i = indexmap[it->first];
                 if (fds[i].fd >= 0 && fds[i].revents) {
                     DXOUT("[S]FD-" << it->first << ": revents: " << fds[i].revents);
-                    it->second->notify(*this);
+                    if (mask(IObserver::OT_READ) & fds[i].revents) {
+                        it->second->notify(*this, OT_READ, 0);
+                    }
+                    if (mask(IObserver::OT_WRITE) & fds[i].revents) {
+                        it->second->notify(*this, OT_WRITE, 0);
+                    }
+                    if (mask(IObserver::OT_EXCEPTION) & fds[i].revents) {
+                        it->second->notify(*this, OT_EXCEPTION, 0);
+                    }
                 }
             }
         }
     }
 }
 
-void EventPollLoop::reserve(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    t_socket_reservation pre = {socket, from, to};
-    if (from != OT_NONE && to == OT_NONE) {
-        clearqueue.push_back(pre);
-    }
-    if (from != OT_NONE && to != OT_NONE) {
+void EventPollLoop::reserve(ISocketLike *socket, observation_category cat, bool in) {
+    t_socket_reservation pre = {socket->get_fd(), socket, cat, in};
+    if (cat == OT_NONE && in) {
+        holdqueue.push_back(pre);
+    } else if (cat == OT_NONE && !in) {
+        unholdqueue.push_back(pre);
+    } else {
         movequeue.push_back(pre);
     }
-    if (from == OT_NONE && to != OT_NONE) {
-        setqueue.push_back(pre);
-    }
 }
 
-// このソケットを監視対象から除外する
-// (その際ソケットはdeleteされる)
-void EventPollLoop::reserve_clear(ISocketLike *socket, t_observation_target from) {
-    reserve(socket, from, OT_NONE);
+void EventPollLoop::reserve_hold(ISocketLike *socket) {
+    reserve(socket, OT_NONE, true);
 }
 
-// このソケットを監視対象に追加する
-void EventPollLoop::reserve_set(ISocketLike *socket, t_observation_target to) {
-    reserve(socket, OT_NONE, to);
+void EventPollLoop::reserve_unhold(ISocketLike *socket) {
+    reserve(socket, OT_NONE, false);
 }
 
-// このソケットの監視方法を変更する
-void EventPollLoop::reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    reserve(socket, from, to);
+// 次の poll の前に, このソケットを監視対象から除外する
+void EventPollLoop::reserve_unset(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, false);
 }
 
-t_poll_eventmask EventPollLoop::mask(t_observation_target t) {
+// 次の poll の前に, このソケットを監視対象に追加する
+void EventPollLoop::reserve_set(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, true);
+}
+
+t_poll_eventmask EventPollLoop::mask(observation_category t) {
     switch (t) {
         case OT_READ:
             return POLLIN;
@@ -84,41 +95,54 @@ t_poll_eventmask EventPollLoop::mask(t_observation_target t) {
 
 // ソケットの監視状態変更予約を実施する
 void EventPollLoop::update() {
-    EventPollLoop::update_queue::iterator it;
-    for (it = clearqueue.begin(); it != clearqueue.end(); it++) {
-        ISocketLike *sock = it->sock;
-        size_t i          = indexmap[sock->get_fd()];
-        fds[i].fd         = -1;
-        sockmap.erase(sock->get_fd());
-        indexmap.erase(sock->get_fd());
-        gapset.insert(i);
+    // exec unhold
+
+    for (EventPollLoop::update_queue::size_type i = 0; i < unholdqueue.size(); ++i) {
+        t_fd fd           = unholdqueue[i].fd;
+        ISocketLike *sock = unholdqueue[i].sock;
+        size_t index      = indexmap[fd];
+
+        // std::cout << "unholding: " << it->fd << std::endl;
+        // DXOUT("unholding: " << it->sock);
+        fds[index].fd = -1;
+        sockmap.erase(fd);
+        indexmap.erase(fd);
+        gapset.insert(index);
         delete sock;
         nfds--;
     }
-    for (it = movequeue.begin(); it != movequeue.end(); it++) {
-        ISocketLike *sock = it->sock;
-        size_t i          = indexmap[sock->get_fd()];
-        fds[i].events     = mask(it->to);
-    }
-    for (it = setqueue.begin(); it != setqueue.end(); it++) {
-        ISocketLike *sock = it->sock;
-        size_t i;
+    // exec hold
+    for (EventPollLoop::update_queue::size_type i = 0; i < holdqueue.size(); ++i) {
+        ISocketLike *sock = holdqueue[i].sock;
+        t_fd fd           = holdqueue[i].fd;
+        size_t idx;
         if (gapset.empty()) {
             pollfd p = {};
-            p.fd     = sock->get_fd();
-            i        = fds.size();
+            p.fd     = fd;
+            idx      = fds.size();
             fds.push_back(p);
         } else {
-            i         = *(gapset.begin());
-            fds[i].fd = sock->get_fd();
+            idx         = *(gapset.begin());
+            fds[idx].fd = fd;
             gapset.erase(gapset.begin());
         }
-        fds[i].events            = mask(it->to);
-        sockmap[sock->get_fd()]  = sock;
-        indexmap[sock->get_fd()] = i;
+        fds[idx].events = 0;
+        sockmap[fd]     = sock;
+        indexmap[fd]    = idx;
         nfds++;
     }
-    clearqueue.clear();
+    // exec set / unset
+    for (EventPollLoop::update_queue::size_type i = 0; i < movequeue.size(); ++i) {
+        t_fd fd         = movequeue[i].fd;
+        size_t idx      = indexmap[fd];
+        fds[idx].events = fds[idx].events | mask(movequeue[i].cat);
+        if (!movequeue[i].in) {
+            fds[idx].events = fds[idx].events ^ mask(movequeue[i].cat);
+        }
+    }
+    unholdqueue.clear();
     movequeue.clear();
-    setqueue.clear();
+    holdqueue.clear();
+
+    // exec unhold
 }

--- a/src/event/Eventpollloop.cpp
+++ b/src/event/Eventpollloop.cpp
@@ -102,8 +102,6 @@ void EventPollLoop::update() {
         ISocketLike *sock = unholdqueue[i].sock;
         size_t index      = indexmap[fd];
 
-        // std::cout << "unholding: " << it->fd << std::endl;
-        // DXOUT("unholding: " << it->sock);
         fds[index].fd = -1;
         sockmap.erase(fd);
         indexmap.erase(fd);

--- a/src/event/Eventpollloop.hpp
+++ b/src/event/Eventpollloop.hpp
@@ -1,7 +1,7 @@
 #ifndef EVENT_POLL_LOOP_HPP
 #define EVENT_POLL_LOOP_HPP
 #include "../interface/IObserver.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include <errno.h>
 #include <map>
 #include <poll.h>
@@ -29,15 +29,16 @@ private:
     socket_map sockmap;
     index_map indexmap;
     gap_set gapset;
+    socket_map holding_map;
     int nfds;
 
-    update_queue clearqueue;
+    update_queue unholdqueue;
     update_queue movequeue;
-    update_queue setqueue;
+    update_queue holdqueue;
 
-    t_poll_eventmask mask(t_observation_target t);
+    t_poll_eventmask mask(observation_category t);
 
-    void reserve(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void reserve(ISocketLike *socket, observation_category cat, bool in);
     void update();
 
 public:
@@ -45,9 +46,10 @@ public:
     ~EventPollLoop();
 
     void loop();
-    void reserve_clear(ISocketLike *socket, t_observation_target from);
-    void reserve_set(ISocketLike *socket, t_observation_target to);
-    void reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void reserve_hold(ISocketLike *socket);
+    void reserve_unhold(ISocketLike *socket);
+    void reserve_unset(ISocketLike *socket, observation_category cat);
+    void reserve_set(ISocketLike *socket, observation_category to);
 };
 
 #endif

--- a/src/event/Eventselectloop.cpp
+++ b/src/event/Eventselectloop.cpp
@@ -2,7 +2,7 @@
 #include "../utils/test_common.hpp"
 
 void EventSelectLoop::destroy_all(EventSelectLoop::socket_map &m) {
-    for (EventSelectLoop::socket_map::iterator it = m.begin(); it != m.end(); it++) {
+    for (EventSelectLoop::socket_map::iterator it = m.begin(); it != m.end(); ++it) {
         delete it->second;
     }
 }
@@ -15,32 +15,32 @@ EventSelectLoop::~EventSelectLoop() {
     destroy_all(exception_map);
 }
 
-void EventSelectLoop::watch(ISocketLike *socket, t_observation_target map_type) {
+void EventSelectLoop::watch(t_fd fd, ISocketLike *socket, observation_category map_type) {
     switch (map_type) {
         case OT_READ:
-            read_map[socket->get_fd()] = socket;
+            read_map[fd] = socket;
             break;
         case OT_WRITE:
-            write_map[socket->get_fd()] = socket;
+            write_map[fd] = socket;
             break;
         case OT_EXCEPTION:
-            exception_map[socket->get_fd()] = socket;
+            exception_map[fd] = socket;
             break;
         default:
             throw std::runtime_error("unexpected map_type");
     }
 }
 
-void EventSelectLoop::unwatch(ISocketLike *socket, t_observation_target map_type) {
+void EventSelectLoop::unwatch(t_fd fd, observation_category map_type) {
     switch (map_type) {
         case OT_READ:
-            read_map.erase(socket->get_fd());
+            read_map.erase(fd);
             break;
         case OT_WRITE:
-            write_map.erase(socket->get_fd());
+            write_map.erase(fd);
             break;
         case OT_EXCEPTION:
-            exception_map.erase(socket->get_fd());
+            exception_map.erase(fd);
             break;
         default:
             throw std::runtime_error("unexpected map_type");
@@ -50,20 +50,23 @@ void EventSelectLoop::unwatch(ISocketLike *socket, t_observation_target map_type
 // ソケットマップ sockmap をFD集合 socketset に変換する
 void EventSelectLoop::prepare_fd_set(socket_map &sockmap, fd_set *sockset) {
     FD_ZERO(sockset);
-    for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
+    for (socket_map::iterator it = sockmap.begin(); it != sockmap.end(); ++it) {
         FD_SET(it->first, sockset);
     }
 }
 
 // sockmap 中のソケットがFD集合 socketset に含まれるかどうかを調べ,
 // 含まれている場合はソケットの notify メソッドを実行する
-void EventSelectLoop::scan_fd_set(socket_map &sockmap, fd_set *sockset, t_time_epoch_ms now) {
-    for (EventSelectLoop::socket_map::iterator it = sockmap.begin(); it != sockmap.end(); it++) {
-        if (now == 0) {
-            it->second->timeout(*this, now);
+void EventSelectLoop::scan_fd_set(socket_map &sockmap,
+                                  fd_set *sockset,
+                                  t_time_epoch_ms now,
+                                  IObserver::observation_category cat) {
+    for (EventSelectLoop::socket_map::iterator it = sockmap.begin(); it != sockmap.end(); ++it) {
+        if (cat == OT_TIMEOUT) {
+            it->second->notify(*this, OT_TIMEOUT, now);
         } else {
             if (FD_ISSET(it->first, sockset)) {
-                it->second->notify(*this);
+                it->second->notify(*this, cat, 0);
             }
         }
     }
@@ -100,48 +103,71 @@ void EventSelectLoop::loop() {
         } else if (count == 0) {
             t_time_epoch_ms now = WSTime::get_epoch_ms();
             DXOUT("timeout?: " << now);
-            scan_fd_set(read_map, &read_set, now);
-            scan_fd_set(write_map, &write_set, now);
-            scan_fd_set(exception_map, &exception_set, now);
+            scan_fd_set(read_map, &read_set, now, OT_TIMEOUT);
+            scan_fd_set(write_map, &write_set, now, OT_TIMEOUT);
+            scan_fd_set(exception_map, &exception_set, now, OT_TIMEOUT);
         } else {
-            scan_fd_set(read_map, &read_set, 0);
-            scan_fd_set(write_map, &write_set, 0);
-            scan_fd_set(exception_map, &exception_set, 0);
+            scan_fd_set(read_map, &read_set, 0, OT_READ);
+            scan_fd_set(write_map, &write_set, 0, OT_WRITE);
+            scan_fd_set(exception_map, &exception_set, 0, OT_EXCEPTION);
         }
     }
 }
 
-void EventSelectLoop::reserve(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    t_socket_reservation pre = {socket, from, to};
+void EventSelectLoop::reserve(ISocketLike *socket, observation_category cat, bool in) {
+    t_socket_reservation pre = {socket->get_fd(), socket, cat, in};
     up_queue.push_back(pre);
 }
 
-// 次のselectの前に, このソケットを監視対象から除外する
-// (その際ソケットはdeleteされる)
-void EventSelectLoop::reserve_clear(ISocketLike *socket, t_observation_target from) {
-    reserve(socket, from, OT_NONE);
+void EventSelectLoop::reserve_hold(ISocketLike *socket) {
+    reserve(socket, OT_NONE, true);
 }
 
-// 次のselectの前に, このソケットを監視対象に追加する
-void EventSelectLoop::reserve_set(ISocketLike *socket, t_observation_target to) {
-    reserve(socket, OT_NONE, to);
+void EventSelectLoop::reserve_unhold(ISocketLike *socket) {
+    reserve(socket, OT_READ, false);
+    reserve(socket, OT_WRITE, false);
+    reserve(socket, OT_EXCEPTION, false);
+    reserve(socket, OT_NONE, false);
 }
 
-// 次のselectの前に, このソケットの監視方法を変更する
-void EventSelectLoop::reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to) {
-    reserve(socket, from, to);
+void EventSelectLoop::reserve_unset(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, false);
+}
+
+void EventSelectLoop::reserve_set(ISocketLike *socket, observation_category cat) {
+    reserve(socket, cat, true);
 }
 
 // ソケットの監視状態変更予約を実施する
 void EventSelectLoop::update() {
-    for (EventSelectLoop::update_queue::iterator it = up_queue.begin(); it != up_queue.end(); it++) {
-        if (it->from != OT_NONE) {
-            unwatch(it->sock, it->from);
+    // exec hold
+    for (update_queue::size_type i = 0; i < up_queue.size(); ++i) {
+        ISocketLike *sock = up_queue[i].sock;
+        t_fd fd           = up_queue[i].fd;
+        if (up_queue[i].cat == OT_NONE && up_queue[i].in) {
+            holding_map.insert(socket_map::value_type(fd, sock));
         }
-        if (it->to != OT_NONE) {
-            watch(it->sock, it->to);
+    }
+
+    // exec set or unset
+    for (update_queue::size_type i = 0; i < up_queue.size(); ++i) {
+        if (up_queue[i].cat == OT_NONE) {
+            continue;
+        }
+        if (up_queue[i].in) {
+            watch(up_queue[i].fd, up_queue[i].sock, up_queue[i].cat);
         } else {
-            delete it->sock;
+            unwatch(up_queue[i].fd, up_queue[i].cat);
+        }
+    }
+
+    // exec unhold
+    for (update_queue::size_type i = 0; i < up_queue.size(); ++i) {
+        ISocketLike *sock = up_queue[i].sock;
+        t_fd fd           = up_queue[i].fd;
+        if (up_queue[i].cat == OT_NONE && !up_queue[i].in) {
+            holding_map.erase(fd);
+            delete sock;
         }
     }
     up_queue.clear();

--- a/src/event/Eventselectloop.cpp
+++ b/src/event/Eventselectloop.cpp
@@ -142,10 +142,8 @@ void EventSelectLoop::reserve_set(ISocketLike *socket, observation_category cat)
 void EventSelectLoop::update() {
     // exec hold
     for (update_queue::size_type i = 0; i < up_queue.size(); ++i) {
-        ISocketLike *sock = up_queue[i].sock;
-        t_fd fd           = up_queue[i].fd;
         if (up_queue[i].cat == OT_NONE && up_queue[i].in) {
-            holding_map.insert(socket_map::value_type(fd, sock));
+            holding_map.insert(socket_map::value_type(up_queue[i].fd, up_queue[i].sock));
         }
     }
 
@@ -163,11 +161,9 @@ void EventSelectLoop::update() {
 
     // exec unhold
     for (update_queue::size_type i = 0; i < up_queue.size(); ++i) {
-        ISocketLike *sock = up_queue[i].sock;
-        t_fd fd           = up_queue[i].fd;
         if (up_queue[i].cat == OT_NONE && !up_queue[i].in) {
-            holding_map.erase(fd);
-            delete sock;
+            holding_map.erase(up_queue[i].fd);
+            delete up_queue[i].sock;
         }
     }
     up_queue.clear();

--- a/src/event/Eventselectloop.hpp
+++ b/src/event/Eventselectloop.hpp
@@ -2,7 +2,7 @@
 #define EVENT_SELECT_LOOP_HPP
 
 #include "../interface/IObserver.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include <cerrno>
 #include <ctime>
 #include <map>
@@ -21,15 +21,16 @@ private:
     socket_map read_map;
     socket_map write_map;
     socket_map exception_map;
+    socket_map holding_map;
     update_queue up_queue;
 
     void prepare_fd_set(socket_map &sockmap, fd_set *sockset);
-    void scan_fd_set(socket_map &sockmap, fd_set *sockset, t_time_epoch_ms now);
-    void reserve(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void scan_fd_set(socket_map &sockmap, fd_set *sockset, t_time_epoch_ms now, IObserver::observation_category cat);
+    void reserve(ISocketLike *socket, observation_category cat, bool in);
     void update();
 
-    void watch(ISocketLike *socket, t_observation_target map_type);
-    void unwatch(ISocketLike *socket, t_observation_target map_type);
+    void watch(t_fd fd, ISocketLike *socket, observation_category map_type);
+    void unwatch(t_fd fd, observation_category map_type);
 
     void destroy_all(socket_map &m);
 
@@ -38,9 +39,10 @@ public:
     ~EventSelectLoop();
 
     void loop();
-    void reserve_clear(ISocketLike *socket, t_observation_target from);
-    void reserve_set(ISocketLike *socket, t_observation_target to);
-    void reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to);
+    void reserve_hold(ISocketLike *socket);
+    void reserve_unhold(ISocketLike *socket);
+    void reserve_unset(ISocketLike *socket, observation_category cat);
+    void reserve_set(ISocketLike *socket, observation_category to);
 };
 
 #endif

--- a/src/interface/IObserver.hpp
+++ b/src/interface/IObserver.hpp
@@ -1,32 +1,50 @@
 #ifndef IOSERVER_HPP
 #define IOSERVER_HPP
-
-#include "ISocketlike.hpp"
+#include "../socket/SocketType.hpp"
 
 // [ソケット監視者インターフェース]
 // [責務]
 // - ソケットライクオブジェクト(ISocketLike)を保持すること
 // - ソケットライクオブジェクトの状態変化を監視し, 変化があったら通知を出すこと
+
+class ISocketLike;
+
 class IObserver {
 public:
-    enum t_observation_target { OT_NONE, OT_READ, OT_WRITE, OT_EXCEPTION };
+    enum observation_category {
+        OT_NONE,
+        OT_READ,
+        OT_WRITE,
+        OT_EXCEPTION,
+        OT_TIMEOUT,
+        // 以下は, オリジネータに対するイベント通知をコネクションが受け取る時のカテゴリ.
+        // 再送信の際に上のカテゴリから変換されるものであり,
+        // オブザーバがこれを直接通知することはない.
+        OT_ORIGINATOR_READ,
+        OT_ORIGINATOR_WRITE,
+        OT_ORIGINATOR_EXCEPTION,
+        OT_ORIGINATOR_TIMEOUT
+    };
 
     struct t_socket_reservation {
+        t_fd fd;
         ISocketLike *sock;
-        t_observation_target from;
-        t_observation_target to;
+        observation_category cat;
+        bool in;
     };
     virtual ~IObserver(){};
 
     // ソケット監視ループ
     virtual void loop() = 0;
-    // 指定されたソケットライクを, 次回のループ実行前に監視対象から除外し,
-    // 破棄する
-    virtual void reserve_clear(ISocketLike *socket, t_observation_target from) = 0;
+    // 指定されたソケットライクを, 次回のループ実行前に保持する
+    virtual void reserve_hold(ISocketLike *socket) = 0;
+    // 指定されたソケットライクを, 次回のループ実行前に破棄する
+    virtual void reserve_unhold(ISocketLike *socket) = 0;
     // 指定されたソケットライクを, 次回のループ実行前に監視対象へ追加する
-    virtual void reserve_set(ISocketLike *socket, t_observation_target to) = 0;
-    // 指定されたソケットライクについて, 次回のループ実行前に監視方法を変更する
-    virtual void reserve_transit(ISocketLike *socket, t_observation_target from, t_observation_target to) = 0;
+    // 保持していなければ自動的に保持する
+    virtual void reserve_set(ISocketLike *socket, observation_category cat) = 0;
+    // 指定されたソケットライクを, 次回のループ実行前に監視停止する
+    virtual void reserve_unset(ISocketLike *socket, observation_category cat) = 0;
 };
 
 #endif

--- a/src/interface/ISocketlike.hpp
+++ b/src/interface/ISocketlike.hpp
@@ -17,10 +17,7 @@ public:
     // 紐づいているソケットのfdを返す
     virtual t_fd get_fd() const = 0;
     // ソケット監視者からの通知を受け取る
-    virtual void notify(IObserver &observer) = 0;
-    // タイムアウトが疑われる時の処理; timeout
-    // が呼ばれたからと言って即タイムアウトではないことに注意
-    virtual void timeout(IObserver &observer, t_time_epoch_ms epoch) = 0;
+    virtual void notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch) = 0;
 };
 
 #endif

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -9,6 +9,7 @@ HTTPServer::~HTTPServer() {
 void HTTPServer::listen(t_socket_domain sdomain, t_socket_type stype, t_port port) {
     Channel *ch            = new Channel(this, sdomain, stype, port);
     channels[ch->get_id()] = ch;
+    socket_observer_->reserve_hold(ch);
     socket_observer_->reserve_set(ch, IObserver::OT_READ);
 }
 

--- a/src/server/HTTPServer.hpp
+++ b/src/server/HTTPServer.hpp
@@ -4,7 +4,7 @@
 #include "../interface/IObserver.hpp"
 #include "../interface/IOriginator.hpp"
 #include "../interface/IRouter.hpp"
-#include "../interface/ISocketlike.hpp"
+#include "../interface/ISocketLike.hpp"
 #include <map>
 
 // [サーバクラス]


### PR DESCRIPTION
- オブザーバが1つのソケットライクについて複数種類のイベントを同時に監視できるようにした
- オブザーバからソケットライクへの通知方法が`notify`と`timeout`に分かれていたが、`notify`に一本化した
- `notify`による通知内容にイベント種別`cat`と時刻`epoch`を追加した
- オブザーバに対する「ソケットライクの追加」と「監視するイベントの変更」を区別し、それぞれ異なる関数を使うようにした:
  - ソケットライク追加 `reserve_hold`
  - ソケットライク削除 `reserve_unhold`
  - イベント監視開始 `reserve_set`
  - イベント監視停止 `reserve_unset`
