### PR TITLE
#89 #90 configの継承バグ修正 + default_serverのパースを追加

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -10,6 +10,10 @@ void Config::set_host_port(const host_port_pair &hp) {
     host_port_ = hp;
 }
 
+void Config::set_is_default_server(const bool &flag) {
+    is_default_server_ = flag;
+}
+
 bool Config::get_autoindex(const std::string &target) const {
     const ContextLocation &loc = longest_prefix_match_location(ctx_server_, target);
     return loc.autoindex;
@@ -73,7 +77,7 @@ std::string Config::get_upload_store(const std::string &target) const {
 
 bool Config::get_default_server(const std::string &target) const {
     (void)target;
-    return ctx_server_.default_server;
+    return is_default_server_;
 }
 
 /**

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -14,10 +14,10 @@
  * root                 string
  * client_max_body_size long
  * host_port            pair<string, int>
+ * default_server       bool
  * redirect             pair<int, string> -> (status, path)
  * server_name          vector<string>
  * upload_store         string
- * default_server       bool
  * limit_except         set<enum> method
  */
 
@@ -30,6 +30,7 @@ public:
 
     /// Setter
     void set_host_port(const host_port_pair &hp);
+    void set_is_default_server(const bool &flag);
 
     /// Getter
     bool get_autoindex(const std::string &target) const;
@@ -47,9 +48,8 @@ public:
 
 private:
     ContextServer ctx_server_;
-
-    // configに対応するhostとportのペア
     host_port_pair host_port_;
+    bool is_default_server_;
 
     ContextLocation longest_prefix_match_location(const ContextServer &srv, const std::string &path) const;
 };

--- a/src/config/Context.cpp
+++ b/src/config/Context.cpp
@@ -8,16 +8,10 @@ ContextMain::ContextMain(void) {
 }
 ContextMain::~ContextMain(void) {}
 
-ContextServer::ContextServer(const ContextMain &main) {
-    client_max_body_size = main.client_max_body_size;
-    autoindex            = main.autoindex;
-    root                 = main.root;
-    indexes              = main.indexes;
-    error_pages          = main.error_pages;
-    redirect             = std::make_pair(-1, "");
-}
+ContextServer::ContextServer(void) : redirect(std::make_pair(-1, "")) {}
 ContextServer::~ContextServer(void) {}
 
+ContextLocation::ContextLocation(void) : redirect(std::make_pair(-1, "")) {}
 ContextLocation::ContextLocation(const ContextServer &server) {
     client_max_body_size = server.client_max_body_size;
     autoindex            = server.autoindex;
@@ -25,6 +19,7 @@ ContextLocation::ContextLocation(const ContextServer &server) {
     indexes              = server.indexes;
     error_pages          = server.error_pages;
     redirect             = server.redirect;
+    upload_store         = server.upload_store;
 }
 ContextLocation::~ContextLocation(void) {}
 

--- a/src/config/Context.cpp
+++ b/src/config/Context.cpp
@@ -8,10 +8,10 @@ ContextMain::ContextMain(void) {
 }
 ContextMain::~ContextMain(void) {}
 
-ContextServer::ContextServer(void) : redirect(std::make_pair(-1, "")) {}
+ContextServer::ContextServer(void) : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")) {}
 ContextServer::~ContextServer(void) {}
 
-ContextLocation::ContextLocation(void) : redirect(std::make_pair(-1, "")) {}
+ContextLocation::ContextLocation(void) : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")) {}
 ContextLocation::ContextLocation(const ContextServer &server) {
     client_max_body_size = server.client_max_body_size;
     autoindex            = server.autoindex;

--- a/src/config/Context.hpp
+++ b/src/config/Context.hpp
@@ -10,6 +10,7 @@ namespace config {
 typedef std::string host_type;
 typedef int port_type;
 typedef std::pair<host_type, port_type> host_port_pair;
+static const int REDIRECT_INITIAL_VALUE = -1;
 
 class ContextMain {
 public:

--- a/src/config/Context.hpp
+++ b/src/config/Context.hpp
@@ -27,7 +27,7 @@ public:
 
 class ContextServer {
 public:
-    ContextServer(const ContextMain &main);
+    ContextServer(void);
     ~ContextServer(void);
 
     // 継承する
@@ -43,7 +43,7 @@ public:
     std::vector<class ContextLocation> locations;
     std::pair<int, std::string> redirect;
     std::string upload_store;
-    bool default_server;
+    std::vector<bool> is_default_servers;
 
     // 継承するか判定するときに使用する
     std::map<std::string, bool> defined_;
@@ -61,6 +61,7 @@ public:
 class ContextLocation {
 public:
     ContextLocation(const ContextServer &server);
+    ContextLocation(void);
     ~ContextLocation(void);
 
     /// 継承する

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -445,7 +445,7 @@ void Parser::inherit_loc_to_loc(const ContextLocation &parent, ContextLocation &
     child.indexes      = child.defined_["index"] ? child.indexes : parent.indexes;
     child.error_pages  = child.defined_["error_page"] ? child.error_pages : parent.error_pages;
     child.upload_store = child.defined_["upload_store"] ? child.upload_store : parent.upload_store;
-    child.redirect     = parent.redirect;
+    child.redirect     = (parent.redirect.first == REDIRECT_INITIAL_VALUE) ? child.redirect : parent.redirect;
 }
 
 void Parser::inherit_locations(const ContextLocation &parent, std::vector<ContextLocation> &locs) {


### PR DESCRIPTION
#### 概要
resolve #89 , resolve #90
継承が正しく行えていないバグを修正した。
default_serverのフラグをlistenディレクティブと1対1で対応させるようにした。

#### その他
Q. redirectの継承判定が違う理由は？
A. 親で定義されていた場合は、子が無視されるため。(下記参照)

```
http {
    server {
        listen 80;
        return 1 hoge;
        location /fuga {
            return 2 fuga;
        }
    }
}
```

```
> curl localhost:80
hoge%
> curl localhost:80/fuga
hoge%
```
