### PR TITLE
タイムアウト検出アルゴリズムの改善

### DIFF
--- a/src/event/Eventkqueueloop.cpp
+++ b/src/event/Eventkqueueloop.cpp
@@ -1,9 +1,10 @@
 #include "Eventkqueueloop.hpp"
 #include "../utils/test_common.hpp"
 
-const int EventKqueueLoop::nev = 10;
+const int EventKqueueLoop::nev                          = 10;
+const t_time_epoch_ms EventKqueueLoop::timeout_interval = 1 * 1000;
 
-EventKqueueLoop::EventKqueueLoop() {
+EventKqueueLoop::EventKqueueLoop() : latest_timeout_checked(WSTime::get_epoch_ms()) {
     evlist.resize(10);
     t_kqueue q = kqueue();
     if (q < 0) {
@@ -54,13 +55,16 @@ void EventKqueueLoop::loop() {
         VOUT(count);
         if (count < 0) {
             throw std::runtime_error("kevent error");
-        } else if (count == 0) {
-            t_time_epoch_ms now = WSTime::get_epoch_ms();
+        }
+        t_time_epoch_ms now = WSTime::get_epoch_ms();
+        if (count == 0 || now - latest_timeout_checked > timeout_interval) {
             for (int i = 0; i < count; i++) {
                 const t_fd fd = static_cast<int>(evlist[i].ident);
                 holding_map[fd]->notify(*this, OT_TIMEOUT, now);
             }
-        } else {
+            latest_timeout_checked = now;
+        }
+        if (count > 0) {
             for (int i = 0; i < count; i++) {
                 const t_fd fd            = static_cast<int>(evlist[i].ident);
                 observation_category cat = filter_to_cat(evlist[i].filter);

--- a/src/event/Eventkqueueloop.hpp
+++ b/src/event/Eventkqueueloop.hpp
@@ -32,6 +32,7 @@ private:
     event_list evlist;
     static const int nev;
     t_kqueue kq;
+    t_time_epoch_ms latest_timeout_checked;
 
     t_kfilter filter(observation_category t);
     observation_category filter_to_cat(t_kfilter f);
@@ -43,6 +44,7 @@ public:
     EventKqueueLoop();
     ~EventKqueueLoop();
 
+    const static t_time_epoch_ms timeout_interval;
     void loop();
     void reserve_hold(ISocketLike *socket);
     void reserve_unhold(ISocketLike *socket);

--- a/src/event/Eventpollloop.hpp
+++ b/src/event/Eventpollloop.hpp
@@ -35,6 +35,7 @@ private:
     update_queue unholdqueue;
     update_queue movequeue;
     update_queue holdqueue;
+    t_time_epoch_ms latest_timeout_checked;
 
     t_poll_eventmask mask(observation_category t);
 
@@ -44,6 +45,8 @@ private:
 public:
     EventPollLoop();
     ~EventPollLoop();
+
+    const static t_time_epoch_ms timeout_interval;
 
     void loop();
     void reserve_hold(ISocketLike *socket);

--- a/src/event/Eventselectloop.hpp
+++ b/src/event/Eventselectloop.hpp
@@ -23,6 +23,7 @@ private:
     socket_map exception_map;
     socket_map holding_map;
     update_queue up_queue;
+    t_time_epoch_ms latest_timeout_checked;
 
     void prepare_fd_set(socket_map &sockmap, fd_set *sockset);
     void scan_fd_set(socket_map &sockmap, fd_set *sockset, t_time_epoch_ms now, IObserver::observation_category cat);
@@ -37,6 +38,8 @@ private:
 public:
     EventSelectLoop();
     ~EventSelectLoop();
+
+    const static t_time_epoch_ms timeout_interval;
 
     void loop();
     void reserve_hold(ISocketLike *socket);


### PR DESCRIPTION
resolve #74 

## 改善前のアルゴリズム

監視関数(`select`, `poll`, `kevent`)が**タイムアウトで**返るたびに、
監視中の`ISocketLike`にタイムアウトイベント`OT_TIMEOUT`を通知する。


## 「改善前のアルゴリズム」の問題点

監視関数がタイムアウトで返らない限り、タイムアウトイベントが通知されない。
よって、本来タイムアウトになるべき`ISocketLike`が別の`iSocketLlike`の活動によって隠蔽される。

## 改善後のアルゴリズム

監視関数がタイムアウトで返らなくても、一定時間ごとにタイムアウトイベントが通知されるようにした。

監視関数(`select`, `poll`, `kevent`)が返るたびに、以下を実行する:

1. 監視関数がタイムアウトで返ったか, 現在時刻`now`と「前回のタイムアウト処理の実行時刻`latest_timeout_checked`」の差が一定`timeout_interval`以上の場合
    - 監視中の`ISocketLike`にタイムアウトイベント`OT_TIMEOUT`を通知する。
    - 「前回のタイムアウト処理の実行時刻」を現在時刻に更新する。
2. 監視関数がタイムアウトで返っていない場合は、発生したイベントを`ISocketLike`に通知する。

