### PR TITLE
#109 ディレクティブを追加する(CGI, DELETEメソッドの影響範囲)

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -80,6 +80,16 @@ bool Config::get_default_server(const std::string &target) const {
     return is_default_server_;
 }
 
+bool Config::get_exec_cgi(const std::string &target) const {
+    const ContextLocation &loc = longest_prefix_match_location(ctx_server_, target);
+    return loc.exec_cgi;
+}
+
+bool Config::get_exec_delete(const std::string &target) const {
+    const ContextLocation &loc = longest_prefix_match_location(ctx_server_, target);
+    return loc.exec_delete;
+}
+
 /**
  * サーバーコンテキストの中で最長前方一致するロケーションを返す
  * 一致しない場合はサーバーコンテキストの情報をそのまま継承したロケーションを返す

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -19,6 +19,8 @@
  * server_name          vector<string>
  * upload_store         string
  * limit_except         set<enum> method
+ * exec_cgi             bool
+ * exec_delete          bool
  */
 
 namespace config {
@@ -45,6 +47,8 @@ public:
     std::string get_upload_store(const std::string &target) const;
     bool get_default_server(const std::string &target) const;
     std::set<enum Methods> get_limit_except(const std::string &target) const;
+    bool get_exec_cgi(const std::string &target) const;
+    bool get_exec_delete(const std::string &target) const;
 
 private:
     ContextServer ctx_server_;

--- a/src/config/Context.cpp
+++ b/src/config/Context.cpp
@@ -20,6 +20,8 @@ ContextLocation::ContextLocation(const ContextServer &server) {
     error_pages          = server.error_pages;
     redirect             = server.redirect;
     upload_store         = server.upload_store;
+    exec_cgi             = false;
+    exec_delete          = false;
 }
 ContextLocation::~ContextLocation(void) {}
 

--- a/src/config/Context.hpp
+++ b/src/config/Context.hpp
@@ -78,7 +78,8 @@ public:
     std::string path;
     std::vector<class ContextLocation> locations;
     ContextLimitExcept limit_except;
-
+    bool exec_cgi;
+    bool exec_delete;
     // 継承するか判定するときに使用する
     std::map<std::string, bool> defined_;
 };

--- a/src/config/Parser.hpp
+++ b/src/config/Parser.hpp
@@ -71,6 +71,8 @@ private:
     void add_server_name(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
     void add_client_max_body_size(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
     void add_upload_store(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
+    void add_exec_cgi(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
+    void add_exec_delete(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
 
     bool is_conflicted_server_name(const std::vector<ContextServer> &servers);
     size_t count_nested_locations(const std::stack<ContextType> &ctx) const;

--- a/src/config/Validator.cpp
+++ b/src/config/Validator.cpp
@@ -153,6 +153,10 @@ std::map<std::string, int> setting_directives(void) {
     directives["return"]               = (HTTP_SRV | HTTP_LOC | TAKE12);
     directives["upload_store"]         = (HTTP_SRV | HTTP_LOC | TAKE1);
 
+    /// Original
+    directives["exec_cgi"]    = (HTTP_LOC | FLAG);
+    directives["exec_delete"] = (HTTP_LOC | FLAG);
+
     return directives;
 }
 


### PR DESCRIPTION
#### 概要
```
location /cgi/ {
  exec_cgi on;
}
location /delete/ {
  exec_delete on;
}
```
- `exec_cgi` が `on` になっている場合、そのロケーションはCGIとして扱う。
- `exec_delete` が `on` になっている場合に、deleteリクエストが来たらファイルを削除する。
