### PR TITLE
ParserHelper 修正とテスト

### DIFF
--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -214,12 +214,8 @@ std::pair<bool, unsigned int> ParserHelper::xtou(const HTTP::light_string &str) 
     return std::pair<bool, unsigned int>(true, n);
 }
 
-ParserHelper::byte_string ParserHelper::utos(unsigned int u, unsigned int base) {
-    assert(base == 8 || base == 10 || base == 16);
+ParserHelper::byte_string ParserHelper::utos(unsigned int u) {
     std::stringstream ss;
-    if (base != 10) {
-        ss << std::setbase(base);
-    }
     ss << u;
     return HTTP::strfy(ss.str());
 }

--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -2,6 +2,10 @@
 #include <limits>
 
 IndexRange ParserHelper::find_crlf(const byte_string &str, ssize_t from, ssize_t len) {
+    if ((size_t)(from + len) > str.size()) {
+        len = str.size() - from;
+    }
+
     for (ssize_t i = from; i - from < len; i++) {
         // iは絶対インデックス; strの先頭からの位置
         // DSOUT() << from << ", " << i << ", " << len << ": " << str[i] << "-" << int(str[i]) << std::endl;

--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -190,23 +190,6 @@ ParserHelper::byte_string ParserHelper::normalize_header_key(const HTTP::light_s
     return normalize_header_key(key.str());
 }
 
-unsigned int ParserHelper::stou(const byte_string &str) {
-    std::stringstream ss;
-    std::string rr;
-    unsigned int v;
-
-    ss << str;
-    ss >> v;
-    ss.clear();
-    ss << v;
-    ss >> rr;
-    byte_string r(HTTP::strfy(rr));
-    if (str != r) {
-        throw std::runtime_error("failed to convert string to int");
-    }
-    return v;
-}
-
 std::pair<bool, unsigned int> ParserHelper::xtou(const HTTP::light_string &str) {
     unsigned int n             = 0;
     const HTTP::byte_string xs = HTTP::strfy("0123456789abcdef");
@@ -227,14 +210,36 @@ std::pair<bool, unsigned int> ParserHelper::xtou(const HTTP::light_string &str) 
     return std::pair<bool, unsigned int>(true, n);
 }
 
-unsigned int ParserHelper::stou(const HTTP::light_string &str) {
-    return stou(str.str());
-}
-
-ParserHelper::byte_string ParserHelper::utos(unsigned int u) {
+ParserHelper::byte_string ParserHelper::utos(unsigned int u, unsigned int base) {
+    assert(base == 8 || base == 10 || base == 16);
     std::stringstream ss;
+    if (base != 10) {
+        ss << std::setbase(base);
+    }
     ss << u;
     return HTTP::strfy(ss.str());
+}
+
+std::pair<bool, unsigned int> ParserHelper::str_to_u(const byte_string &str) {
+    std::stringstream ss;
+    std::string rr;
+    unsigned int v;
+
+    ss << str;
+    ss >> v;
+    ss.clear();
+    ss << v;
+    ss >> rr;
+    byte_string r(HTTP::strfy(rr));
+    if (str == r) {
+        return std::make_pair(true, v);
+    } else {
+        return std::make_pair(false, 0);
+    }
+}
+
+std::pair<bool, unsigned int> ParserHelper::str_to_u(const HTTP::light_string &str) {
+    return str_to_u(str.str());
 }
 
 unsigned int ParserHelper::quality_to_u(HTTP::light_string &quality) {

--- a/src/communication/ParserHelper.hpp
+++ b/src/communication/ParserHelper.hpp
@@ -61,7 +61,7 @@ byte_string normalize_header_key(const byte_string &key);
 byte_string normalize_header_key(const HTTP::light_string &key);
 
 std::pair<bool, unsigned int> xtou(const HTTP::light_string &str);
-byte_string utos(unsigned int u, unsigned int base);
+byte_string utos(unsigned int u);
 
 // string to size_t 変換
 std::pair<bool, unsigned int> str_to_u(const byte_string &str);

--- a/src/communication/ParserHelper.hpp
+++ b/src/communication/ParserHelper.hpp
@@ -61,10 +61,11 @@ byte_string normalize_header_key(const byte_string &key);
 byte_string normalize_header_key(const HTTP::light_string &key);
 
 std::pair<bool, unsigned int> xtou(const HTTP::light_string &str);
+byte_string utos(unsigned int u, unsigned int base);
+
 // string to size_t 変換
-unsigned int stou(const byte_string &str);
-unsigned int stou(const HTTP::light_string &str);
-byte_string utos(unsigned int u);
+std::pair<bool, unsigned int> str_to_u(const byte_string &str);
+std::pair<bool, unsigned int> str_to_u(const HTTP::light_string &str);
 
 // quality("q=0.05" の右辺側みたいな形式の文字列)を1000倍したunsigned intに変換
 // qualityとしてvalidなもののみ渡すこと.

--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -600,7 +600,9 @@ void RequestHTTP::RoutingParameters::determine_body_size(const header_holder_typ
         // Transfer-Encodingがなく, Content-Lengthが正当である場合
         // -> Content-Length の値がボディの長さとなる.
         if (cl) {
-            body_size       = ParserHelper::stou(*cl);
+            std::pair<bool, unsigned int> res = ParserHelper::str_to_u(*cl);
+            VOUT(res.first);
+            body_size       = res.second;
             is_body_chunked = false;
             // content-length の値が妥当でない場合, ここで例外が飛ぶ
             DXOUT("body_size = " << body_size);

--- a/src/communication/ValidatorHTTP.cpp
+++ b/src/communication/ValidatorHTTP.cpp
@@ -174,8 +174,13 @@ bool HTTP::Validator::is_ipv4address(const HTTP::light_string &str) {
             DXOUT("[KO] detectec leading zero in ipv4 addr component: " << spl);
             return false;
         }
-        unsigned int elem = ParserHelper::stou(spl);
-        if (255 < elem) {
+        std::pair<bool, unsigned int> elem = ParserHelper::str_to_u(spl);
+        if (!elem.first) {
+            // [NG] 変換失敗
+            DXOUT("[KO] failed to transform uint: " << spl);
+            return false;
+        }
+        if (255 < elem.second) {
             // [NG] 255よりでかい
             DXOUT("[KO] too large ipv4 addr component: " << spl);
             return false;

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -1,0 +1,154 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include "../../src/communication/ParserHelper.hpp"
+
+// [find_crlf]
+
+TEST(parser_helper_find_crlf, basic) {
+    const HTTP::byte_string str = HTTP::strfy("012\r456\n890\r\r345\r\r\r901\r\n\r567\n\r\n123\n\n\n");
+    EXPECT_EQ(IndexRange(7, 8), ParserHelper::find_crlf(str, 0, str.size()));
+    EXPECT_EQ(IndexRange(6, 5), ParserHelper::find_crlf(str, 0, 5));
+    EXPECT_EQ(IndexRange(7, 8), ParserHelper::find_crlf(str, 7, str.size()));
+    EXPECT_EQ(IndexRange(22, 24), ParserHelper::find_crlf(str, 10, str.size()));
+    EXPECT_EQ(IndexRange(36, 37), ParserHelper::find_crlf(str, 36, str.size()));
+    EXPECT_EQ(IndexRange(38, 37), ParserHelper::find_crlf(str, 37, str.size()));
+}
+
+TEST(parser_helper_find_crlf, backward) {
+    const HTTP::byte_string str = HTTP::strfy("\r\n\n");
+    EXPECT_EQ(IndexRange(0, 2), ParserHelper::find_crlf(str, 0, str.size()));
+    EXPECT_EQ(IndexRange(2, 1), ParserHelper::find_crlf(str, 0, 1));
+    EXPECT_EQ(IndexRange(0, 2), ParserHelper::find_crlf(str, 1, str.size()));
+    EXPECT_EQ(IndexRange(2, 3), ParserHelper::find_crlf(str, 2, str.size()));
+}
+
+TEST(parser_helper_find_crlf, nothing) {
+    const HTTP::byte_string str = HTTP::strfy("aiueo");
+    EXPECT_EQ(IndexRange(1, 0), ParserHelper::find_crlf(str, 0, 0));
+    EXPECT_EQ(IndexRange(str.size() + 1, str.size()), ParserHelper::find_crlf(str, 0, str.size()));
+}
+
+// [find_crlf_header_value]
+
+// [find_obs_fold]
+
+// [ignore_crlf]
+
+// [is_sp]
+TEST(parser_helper_is_sp, is_sp) {
+    EXPECT_EQ(true, ParserHelper::is_sp(ParserHelper::SP[0]));
+    EXPECT_EQ(false, ParserHelper::is_sp('\t'));
+    EXPECT_EQ(false, ParserHelper::is_sp('a'));
+    EXPECT_EQ(false, ParserHelper::is_sp('\v'));
+    EXPECT_EQ(false, ParserHelper::is_sp('\n'));
+    EXPECT_EQ(false, ParserHelper::is_sp('\r'));
+}
+
+// [ignore_sp]
+
+// [ignore_not_sp]
+
+// [find_leading_crlf]
+
+// [split_by_sp]
+
+// [split]
+
+// [normalize_header_key]
+
+// [xtou]
+
+// [str_to_u]
+TEST(parser_helper_str_to_u, is_0) {
+    const HTTP::byte_string str = HTTP::strfy("0");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(true, res.first);
+    EXPECT_EQ(0, res.second);
+}
+
+TEST(parser_helper_str_to_u, is_1) {
+    const HTTP::byte_string str = HTTP::strfy("1");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(true, res.first);
+    EXPECT_EQ(1, res.second);
+}
+
+TEST(parser_helper_str_to_u, is_UINT_MAX_less_1) {
+    const HTTP::byte_string str = HTTP::strfy("4294967294");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(true, res.first);
+    EXPECT_EQ(UINT_MAX - 1, res.second);
+}
+
+TEST(parser_helper_str_to_u, is_UINT_MAX) {
+    const HTTP::byte_string str = HTTP::strfy("4294967295");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(true, res.first);
+    EXPECT_EQ(UINT_MAX, res.second);
+}
+
+TEST(parser_helper_str_to_u, is_UINT_MAX_with_leading_0) {
+    const HTTP::byte_string str = HTTP::strfy("0000000004294967295");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(false, res.first);
+}
+
+TEST(parser_helper_str_to_u, is_UINT_MAX_plus_1) {
+    const HTTP::byte_string str = HTTP::strfy("4294967296");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(false, res.first);
+}
+
+TEST(parser_helper_str_to_u, is_minus_1) {
+    const HTTP::byte_string str = HTTP::strfy("-1");
+    std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
+    EXPECT_EQ(false, res.first);
+}
+
+// [utos]
+TEST(parser_helper_utos, from_0) {
+    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 8));
+    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 10));
+    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 16));
+}
+
+TEST(parser_helper_utos, from_1) {
+    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 8));
+    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 10));
+    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 16));
+}
+
+TEST(parser_helper_utos, from_8) {
+    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(8, 8));
+    EXPECT_EQ(HTTP::strfy("8"), ParserHelper::utos(8, 10));
+    EXPECT_EQ(HTTP::strfy("8"), ParserHelper::utos(8, 16));
+}
+
+TEST(parser_helper_utos, from_10) {
+    EXPECT_EQ(HTTP::strfy("12"), ParserHelper::utos(10, 8));
+    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(10, 10));
+    EXPECT_EQ(HTTP::strfy("a"), ParserHelper::utos(10, 16));
+}
+
+TEST(parser_helper_utos, from_16) {
+    EXPECT_EQ(HTTP::strfy("20"), ParserHelper::utos(16, 8));
+    EXPECT_EQ(HTTP::strfy("16"), ParserHelper::utos(16, 10));
+    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(16, 16));
+}
+
+TEST(parser_helper_utos, from_UINT_MAX) {
+    EXPECT_EQ(HTTP::strfy("37777777776"), ParserHelper::utos(UINT_MAX - 1, 8));
+    EXPECT_EQ(HTTP::strfy("4294967294"), ParserHelper::utos(UINT_MAX - 1, 10));
+    EXPECT_EQ(HTTP::strfy("fffffffe"), ParserHelper::utos(UINT_MAX - 1, 16));
+}
+
+TEST(parser_helper_utos, from_UINT_MAX_minus_1) {
+    EXPECT_EQ(HTTP::strfy("37777777777"), ParserHelper::utos(UINT_MAX, 8));
+    EXPECT_EQ(HTTP::strfy("4294967295"), ParserHelper::utos(UINT_MAX, 10));
+    EXPECT_EQ(HTTP::strfy("ffffffff"), ParserHelper::utos(UINT_MAX, 16));
+}
+
+// [quality_to_u]
+
+// [extract_quoted_or_token]
+

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -105,49 +105,6 @@ TEST(parser_helper_str_to_u, is_minus_1) {
     EXPECT_EQ(false, res.first);
 }
 
-// [utos]
-TEST(parser_helper_utos, from_0) {
-    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 8));
-    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 10));
-    EXPECT_EQ(HTTP::strfy("0"), ParserHelper::utos(0, 16));
-}
-
-TEST(parser_helper_utos, from_1) {
-    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 8));
-    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 10));
-    EXPECT_EQ(HTTP::strfy("1"), ParserHelper::utos(1, 16));
-}
-
-TEST(parser_helper_utos, from_8) {
-    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(8, 8));
-    EXPECT_EQ(HTTP::strfy("8"), ParserHelper::utos(8, 10));
-    EXPECT_EQ(HTTP::strfy("8"), ParserHelper::utos(8, 16));
-}
-
-TEST(parser_helper_utos, from_10) {
-    EXPECT_EQ(HTTP::strfy("12"), ParserHelper::utos(10, 8));
-    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(10, 10));
-    EXPECT_EQ(HTTP::strfy("a"), ParserHelper::utos(10, 16));
-}
-
-TEST(parser_helper_utos, from_16) {
-    EXPECT_EQ(HTTP::strfy("20"), ParserHelper::utos(16, 8));
-    EXPECT_EQ(HTTP::strfy("16"), ParserHelper::utos(16, 10));
-    EXPECT_EQ(HTTP::strfy("10"), ParserHelper::utos(16, 16));
-}
-
-TEST(parser_helper_utos, from_UINT_MAX) {
-    EXPECT_EQ(HTTP::strfy("37777777776"), ParserHelper::utos(UINT_MAX - 1, 8));
-    EXPECT_EQ(HTTP::strfy("4294967294"), ParserHelper::utos(UINT_MAX - 1, 10));
-    EXPECT_EQ(HTTP::strfy("fffffffe"), ParserHelper::utos(UINT_MAX - 1, 16));
-}
-
-TEST(parser_helper_utos, from_UINT_MAX_minus_1) {
-    EXPECT_EQ(HTTP::strfy("37777777777"), ParserHelper::utos(UINT_MAX, 8));
-    EXPECT_EQ(HTTP::strfy("4294967295"), ParserHelper::utos(UINT_MAX, 10));
-    EXPECT_EQ(HTTP::strfy("ffffffff"), ParserHelper::utos(UINT_MAX, 16));
-}
-
 // [quality_to_u]
 
 // [extract_quoted_or_token]

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -1,6 +1,6 @@
+#include "../../src/communication/ParserHelper.hpp"
 #include "gtest/gtest.h"
 #include <vector>
-#include "../../src/communication/ParserHelper.hpp"
 
 // [find_crlf]
 
@@ -60,47 +60,47 @@ TEST(parser_helper_is_sp, is_sp) {
 
 // [str_to_u]
 TEST(parser_helper_str_to_u, is_0) {
-    const HTTP::byte_string str = HTTP::strfy("0");
+    const HTTP::byte_string str       = HTTP::strfy("0");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(true, res.first);
     EXPECT_EQ(0, res.second);
 }
 
 TEST(parser_helper_str_to_u, is_1) {
-    const HTTP::byte_string str = HTTP::strfy("1");
+    const HTTP::byte_string str       = HTTP::strfy("1");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(true, res.first);
     EXPECT_EQ(1, res.second);
 }
 
 TEST(parser_helper_str_to_u, is_UINT_MAX_less_1) {
-    const HTTP::byte_string str = HTTP::strfy("4294967294");
+    const HTTP::byte_string str       = HTTP::strfy("4294967294");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(true, res.first);
     EXPECT_EQ(UINT_MAX - 1, res.second);
 }
 
 TEST(parser_helper_str_to_u, is_UINT_MAX) {
-    const HTTP::byte_string str = HTTP::strfy("4294967295");
+    const HTTP::byte_string str       = HTTP::strfy("4294967295");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(true, res.first);
     EXPECT_EQ(UINT_MAX, res.second);
 }
 
 TEST(parser_helper_str_to_u, is_UINT_MAX_with_leading_0) {
-    const HTTP::byte_string str = HTTP::strfy("0000000004294967295");
+    const HTTP::byte_string str       = HTTP::strfy("0000000004294967295");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(false, res.first);
 }
 
 TEST(parser_helper_str_to_u, is_UINT_MAX_plus_1) {
-    const HTTP::byte_string str = HTTP::strfy("4294967296");
+    const HTTP::byte_string str       = HTTP::strfy("4294967296");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(false, res.first);
 }
 
 TEST(parser_helper_str_to_u, is_minus_1) {
-    const HTTP::byte_string str = HTTP::strfy("-1");
+    const HTTP::byte_string str       = HTTP::strfy("-1");
     std::pair<bool, unsigned int> res = ParserHelper::str_to_u(str);
     EXPECT_EQ(false, res.first);
 }
@@ -151,4 +151,3 @@ TEST(parser_helper_utos, from_UINT_MAX_minus_1) {
 // [quality_to_u]
 
 // [extract_quoted_or_token]
-


### PR DESCRIPTION
とりあえずできてるやつ。

---

`ParserHelper::stou`は文字列 -> uint変換をするが、変換できない場合は例外を投げてしまうので、
例外を投げず失敗フラグを返す関数`ParserHelpher::str_to_u`に切り替えた。