### PR TITLE
RequestHTTPからリクエストマッチングのための情報を取り出せるようにする

### DIFF
--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -636,6 +636,22 @@ void RequestHTTP::RoutingParameters::determine_host(const header_holder_type &ho
     pack_host(header_host, lhost);
 }
 
+const RequestTarget &RequestHTTP::RoutingParameters::get_request_target() const {
+    return given_request_target;
+}
+
+HTTP::t_method RequestHTTP::RoutingParameters::get_http_method() const {
+    return http_method;
+}
+
+HTTP::t_version RequestHTTP::RoutingParameters::get_http_version() const {
+    return http_version;
+}
+
+const HTTP::CH::Host &RequestHTTP::RoutingParameters::get_host() const {
+    return header_host;
+}
+
 bool RequestHTTP::is_routable() const {
     return this->ps.parse_progress >= PP_BODY;
 }
@@ -699,4 +715,8 @@ bool RequestHTTP::should_keep_in_touch() const {
 
 RequestHTTP::header_holder_type::joined_dict_type RequestHTTP::get_cgi_http_vars() const {
     return header_holder.get_cgi_http_vars();
+}
+
+const IRequestMatchingParam &RequestHTTP::get_request_mathing_param() const {
+    return rp;
 }

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -247,6 +247,7 @@ public:
     bool should_keep_in_touch() const;
 
     header_holder_type::joined_dict_type get_cgi_http_vars() const;
+    const IRequestMatchingParam &get_request_mathing_param() const;
 };
 
 #endif

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -57,6 +57,16 @@ struct RequestTarget {
 
 std::ostream &operator<<(std::ostream &ost, const RequestTarget &f);
 
+class IRequestMatchingParam {
+public:
+    virtual ~IRequestMatchingParam() {}
+
+    virtual const RequestTarget &get_request_target() const = 0;
+    virtual HTTP::t_method get_http_method() const          = 0;
+    virtual HTTP::t_version get_http_version() const        = 0;
+    virtual const HTTP::CH::Host &get_host() const          = 0;
+};
+
 // [HTTPリクエストクラス]
 // [責務]
 // - 順次供給されるバイト列をHTTPリクエストとして解釈すること
@@ -118,15 +128,16 @@ public:
     };
 
     // リクエストの制御, ルーティングにかかわるパラメータ
-    struct RoutingParameters : public ARoutingParameters {
-        RequestTarget given_request_target;
+    struct RoutingParameters : public ARoutingParameters, public IRequestMatchingParam {
+        // TODO: リクエストマッチングに必要なものを外部に公開する
+        RequestTarget given_request_target; // リクエストマッチングに必要
 
-        HTTP::t_method http_method;
+        HTTP::t_method http_method; // リクエストマッチングに必要
         HTTP::t_version http_version;
 
         bool is_body_chunked;
 
-        HTTP::CH::Host header_host;
+        HTTP::CH::Host header_host; // リクエストマッチングに必要
         HTTP::CH::ContentType content_type;
         HTTP::CH::TransferEncoding transfer_encoding;
         HTTP::CH::Connection connection;
@@ -140,6 +151,11 @@ public:
         void determine_host(const header_holder_type &holder);
         // リクエストのボディサイズ(にかかわるパラメータ)を決定する
         void determine_body_size(const header_holder_type &holder);
+
+        const RequestTarget &get_request_target() const;
+        HTTP::t_method get_http_method() const;
+        HTTP::t_version get_http_version() const;
+        const HTTP::CH::Host &get_host() const;
     };
 
 private:


### PR DESCRIPTION
`RequestHTTP::get_request_mathing_param`でインターフェース`IRequestMatchingParam`の参照が取れる。
`IRequestMatchingParam`はリクエストマッチングに必要な情報のgetterをすべて含む(はず)。

~~(PRのマージ待ちの都合上コンパイル通りません)~~