### PR TITLE
configで拡張子と対応するエグゼキュータのパスを指定できるようにした

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -90,7 +90,7 @@ bool Config::get_exec_delete(const std::string &target) const {
     return loc.exec_delete;
 }
 
-std::map<extension, executer_path> Config::get_cgi_path(const std::string &target) const {
+cgi_path_map Config::get_cgi_path(const std::string &target) const {
     const ContextLocation &loc = longest_prefix_match_location(ctx_server_, target);
     return loc.cgi_paths;
 }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -90,6 +90,11 @@ bool Config::get_exec_delete(const std::string &target) const {
     return loc.exec_delete;
 }
 
+std::map<extension, executer_path> Config::get_cgi_path(const std::string &target) const {
+    const ContextLocation &loc = longest_prefix_match_location(ctx_server_, target);
+    return loc.cgi_paths;
+}
+
 /**
  * サーバーコンテキストの中で最長前方一致するロケーションを返す
  * 一致しない場合はサーバーコンテキストの情報をそのまま継承したロケーションを返す

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -21,6 +21,7 @@
  * limit_except         set<enum> method
  * exec_cgi             bool
  * exec_delete          bool
+ * cgi_paths           map<string, string> -> extension, executer_path
  */
 
 namespace config {
@@ -49,6 +50,7 @@ public:
     std::set<enum Methods> get_limit_except(const std::string &target) const;
     bool get_exec_cgi(const std::string &target) const;
     bool get_exec_delete(const std::string &target) const;
+    std::map<extension, executer_path> get_cgi_path(const std::string &target) const;
 
 private:
     ContextServer ctx_server_;

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -50,7 +50,7 @@ public:
     std::set<enum Methods> get_limit_except(const std::string &target) const;
     bool get_exec_cgi(const std::string &target) const;
     bool get_exec_delete(const std::string &target) const;
-    std::map<extension, executer_path> get_cgi_path(const std::string &target) const;
+    cgi_path_map get_cgi_path(const std::string &target) const;
 
 private:
     ContextServer ctx_server_;

--- a/src/config/Context.hpp
+++ b/src/config/Context.hpp
@@ -10,6 +10,9 @@ namespace config {
 typedef std::string host_type;
 typedef int port_type;
 typedef std::pair<host_type, port_type> host_port_pair;
+typedef std::string extension;
+typedef std::string executer_path;
+
 static const int REDIRECT_INITIAL_VALUE = -1;
 
 class ContextMain {
@@ -78,6 +81,7 @@ public:
     std::string path;
     std::vector<class ContextLocation> locations;
     ContextLimitExcept limit_except;
+    std::map<extension, executer_path> cgi_paths;
     bool exec_cgi;
     bool exec_delete;
     // 継承するか判定するときに使用する

--- a/src/config/Context.hpp
+++ b/src/config/Context.hpp
@@ -10,8 +10,9 @@ namespace config {
 typedef std::string host_type;
 typedef int port_type;
 typedef std::pair<host_type, port_type> host_port_pair;
-typedef std::string extension;
-typedef std::string executer_path;
+typedef std::string extension_type;
+typedef std::string executer_path_type;
+typedef std::map<extension_type, executer_path_type> cgi_path_map;
 
 static const int REDIRECT_INITIAL_VALUE = -1;
 
@@ -81,7 +82,7 @@ public:
     std::string path;
     std::vector<class ContextLocation> locations;
     ContextLimitExcept limit_except;
-    std::map<extension, executer_path> cgi_paths;
+    cgi_path_map cgi_paths;
     bool exec_cgi;
     bool exec_delete;
     // 継承するか判定するときに使用する

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -445,11 +445,11 @@ void Parser::add_exec_delete(const std::vector<std::string> &args, std::stack<Co
 }
 
 void Parser::add_cgi_path(const std::vector<std::string> &args, std::stack<ContextType> &ctx) {
-    ContextLocation *p              = get_current_location(ctx);
-    const std::string extension     = args.front();
-    const std::string executer_path = args.back();
-    p->cgi_paths[extension]         = executer_path;
-    p->defined_["cgi_path"]         = true;
+    ContextLocation *p                     = get_current_location(ctx);
+    const extension_type extension         = args.front();
+    const executer_path_type executer_path = args.back();
+    p->cgi_paths[extension]                = executer_path;
+    p->defined_["cgi_path"]                = true;
 }
 
 /// Inheritance

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -37,6 +37,7 @@ Parser::DirectiveFunctionsMap Parser::setting_directive_functions(void) {
     directives["upload_store"]         = &Parser::add_upload_store;
     directives["exec_cgi"]             = &Parser::add_exec_cgi;
     directives["exec_delete"]          = &Parser::add_exec_delete;
+    directives["cgi_path"]             = &Parser::add_cgi_path;
     return directives;
 }
 
@@ -441,6 +442,14 @@ void Parser::add_exec_delete(const std::vector<std::string> &args, std::stack<Co
     ContextLocation *p         = get_current_location(ctx);
     p->exec_delete             = flag;
     p->defined_["exec_delete"] = true;
+}
+
+void Parser::add_cgi_path(const std::vector<std::string> &args, std::stack<ContextType> &ctx) {
+    ContextLocation *p              = get_current_location(ctx);
+    const std::string extension     = args.front();
+    const std::string executer_path = args.back();
+    p->cgi_paths[extension]         = executer_path;
+    p->defined_["cgi_path"]         = true;
 }
 
 /// Inheritance

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -473,6 +473,7 @@ void Parser::inherit_loc_to_loc(const ContextLocation &parent, ContextLocation &
     child.upload_store = child.defined_["upload_store"] ? child.upload_store : parent.upload_store;
     child.exec_cgi     = child.defined_["exec_cgi"] ? child.exec_cgi : parent.exec_cgi;
     child.exec_delete  = child.defined_["exec_delete"] ? child.exec_delete : parent.exec_delete;
+    child.cgi_paths    = child.defined_["cgi_path"] ? child.cgi_paths : parent.cgi_paths;
     child.redirect     = (parent.redirect.first == REDIRECT_INITIAL_VALUE) ? child.redirect : parent.redirect;
 }
 

--- a/src/config/Parser.hpp
+++ b/src/config/Parser.hpp
@@ -73,6 +73,7 @@ private:
     void add_upload_store(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
     void add_exec_cgi(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
     void add_exec_delete(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
+    void add_cgi_path(const std::vector<std::string> &args, std::stack<ContextType> &ctx);
 
     bool is_conflicted_server_name(const std::vector<ContextServer> &servers);
     size_t count_nested_locations(const std::stack<ContextType> &ctx) const;

--- a/src/config/Validator.cpp
+++ b/src/config/Validator.cpp
@@ -156,6 +156,7 @@ std::map<std::string, int> setting_directives(void) {
     /// Original
     directives["exec_cgi"]    = (HTTP_LOC | FLAG);
     directives["exec_delete"] = (HTTP_LOC | FLAG);
+    directives["cgi_path"]    = (HTTP_LOC | TAKE2);
 
     return directives;
 }

--- a/test_case/test_config_original_directive.cpp
+++ b/test_case/test_config_original_directive.cpp
@@ -14,14 +14,13 @@ protected:
     virtual void SetUp(const std::string &data) {
         configs = parser.parse(data);
     }
-    virtual void TearDown() {}
 
     config::Parser parser;
     std::map<config::host_port_pair, std::vector<config::Config> > configs;
 };
 
 TEST_F(ConfigTest, GetExecCgi) {
-    const std::string test_config = "\
+    const std::string config_data = "\
 http { \
     server { \
         listen 80; \
@@ -34,16 +33,17 @@ http { \
     } \
 } \
 ";
-    SetUp(test_config);
+    SetUp(config_data);
     const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
     const config::Config conf       = configs[hp].front();
+
     EXPECT_EQ(false, conf.get_exec_cgi("/"));
     EXPECT_EQ(true, conf.get_exec_cgi("/on/"));
     EXPECT_EQ(false, conf.get_exec_cgi("/off/"));
 }
 
 TEST_F(ConfigTest, GetExecDelete) {
-    const std::string test_config = "\
+    const std::string config_data = "\
 http { \
     server { \
         listen 80; \
@@ -56,7 +56,7 @@ http { \
     } \
 } \
 ";
-    SetUp(test_config);
+    SetUp(config_data);
     const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
     const config::Config conf       = configs[hp].front();
     EXPECT_EQ(false, conf.get_exec_delete("/"));
@@ -65,7 +65,7 @@ http { \
 }
 
 TEST_F(ConfigTest, GetCgiPath) {
-    const std::string test_config = "\
+    const std::string config_data = "\
 http { \
     server { \
         listen 80; \
@@ -80,18 +80,18 @@ http { \
     } \
 } \
 ";
-    SetUp(test_config);
+    SetUp(config_data);
     const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
     const config::Config conf       = configs[hp].front();
 
     {
-        std::map<config::extension, config::executer_path> expected;
-        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/");
+        const std::map<config::extension, config::executer_path> expected;
+        const std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/");
         EXPECT_EQ(expected.empty(), actual.empty());
     }
     {
         std::map<config::extension, config::executer_path> expected;
-        std::string extension                                     = ".rb";
+        const std::string extension                               = ".rb";
         expected[".rb"]                                           = "/usr/bin/ruby";
         std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/ruby/");
         EXPECT_EQ(expected.size(), actual.size());
@@ -99,7 +99,7 @@ http { \
     }
     {
         std::map<config::extension, config::executer_path> expected;
-        std::string extension                                     = ".py";
+        const std::string extension                               = ".py";
         expected[extension]                                       = "/usr/bin/python";
         std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/python/");
         EXPECT_EQ(expected.size(), actual.size());

--- a/test_case/test_config_original_directive.cpp
+++ b/test_case/test_config_original_directive.cpp
@@ -1,0 +1,110 @@
+#include "../../src/config/Context.hpp"
+#include "../../src/config/File.hpp"
+#include "../../src/config/Lexer.hpp"
+#include "../../src/config/Parser.hpp"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <vector>
+
+namespace {
+class ConfigTest : public testing::Test {
+protected:
+    ConfigTest() {}
+    virtual ~ConfigTest() {}
+    virtual void SetUp(const std::string &data) {
+        configs = parser.parse(data);
+    }
+    virtual void TearDown() {}
+
+    config::Parser parser;
+    std::map<config::host_port_pair, std::vector<config::Config> > configs;
+};
+
+TEST_F(ConfigTest, GetExecCgi) {
+    const std::string test_config = "\
+http { \
+    server { \
+        listen 80; \
+        location /on/ { \
+            exec_cgi on; \
+        } \
+        location /off/ { \
+            exec_cgi off; \
+        } \
+    } \
+} \
+";
+    SetUp(test_config);
+    const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
+    const config::Config conf       = configs[hp].front();
+    EXPECT_EQ(false, conf.get_exec_cgi("/"));
+    EXPECT_EQ(true, conf.get_exec_cgi("/on/"));
+    EXPECT_EQ(false, conf.get_exec_cgi("/off/"));
+}
+
+TEST_F(ConfigTest, GetExecDelete) {
+    const std::string test_config = "\
+http { \
+    server { \
+        listen 80; \
+        location /on/ { \
+            exec_delete on; \
+        } \
+        location /off/ { \
+            exec_delete off; \
+        } \
+    } \
+} \
+";
+    SetUp(test_config);
+    const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
+    const config::Config conf       = configs[hp].front();
+    EXPECT_EQ(false, conf.get_exec_delete("/"));
+    EXPECT_EQ(true, conf.get_exec_delete("/on/"));
+    EXPECT_EQ(false, conf.get_exec_delete("/off/"));
+}
+
+TEST_F(ConfigTest, GetCgiPath) {
+    const std::string test_config = "\
+http { \
+    server { \
+        listen 80; \
+        location /ruby/ { \
+            exec_cgi on; \
+            cgi_path .rb /usr/bin/ruby; \
+        } \
+        location /python/ { \
+            exec_cgi on; \
+            cgi_path .py /usr/bin/python; \
+        } \
+    } \
+} \
+";
+    SetUp(test_config);
+    const config::host_port_pair hp = std::make_pair("0.0.0.0", 80);
+    const config::Config conf       = configs[hp].front();
+
+    {
+        std::map<config::extension, config::executer_path> expected;
+        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/");
+        EXPECT_EQ(expected.empty(), actual.empty());
+    }
+    {
+        std::map<config::extension, config::executer_path> expected;
+        std::string extension                                     = ".rb";
+        expected[".rb"]                                           = "/usr/bin/ruby";
+        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/ruby/");
+        EXPECT_EQ(expected.size(), actual.size());
+        EXPECT_EQ(expected[extension], actual[extension]);
+    }
+    {
+        std::map<config::extension, config::executer_path> expected;
+        std::string extension                                     = ".py";
+        expected[extension]                                       = "/usr/bin/python";
+        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/python/");
+        EXPECT_EQ(expected.size(), actual.size());
+        EXPECT_EQ(expected[extension], actual[extension]);
+    }
+}
+
+} // namespace

--- a/test_case/test_config_original_directive.cpp
+++ b/test_case/test_config_original_directive.cpp
@@ -85,23 +85,23 @@ http { \
     const config::Config conf       = configs[hp].front();
 
     {
-        const std::map<config::extension, config::executer_path> expected;
-        const std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/");
+        const config::cgi_path_map expected;
+        const config::cgi_path_map actual = conf.get_cgi_path("/");
         EXPECT_EQ(expected.empty(), actual.empty());
     }
     {
-        std::map<config::extension, config::executer_path> expected;
-        const std::string extension                               = ".rb";
-        expected[".rb"]                                           = "/usr/bin/ruby";
-        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/ruby/");
+        config::cgi_path_map expected;
+        const std::string extension = ".rb";
+        expected[".rb"]             = "/usr/bin/ruby";
+        config::cgi_path_map actual = conf.get_cgi_path("/ruby/");
         EXPECT_EQ(expected.size(), actual.size());
         EXPECT_EQ(expected[extension], actual[extension]);
     }
     {
-        std::map<config::extension, config::executer_path> expected;
-        const std::string extension                               = ".py";
-        expected[extension]                                       = "/usr/bin/python";
-        std::map<config::extension, config::executer_path> actual = conf.get_cgi_path("/python/");
+        config::cgi_path_map expected;
+        const std::string extension = ".py";
+        expected[extension]         = "/usr/bin/python";
+        config::cgi_path_map actual = conf.get_cgi_path("/python/");
         EXPECT_EQ(expected.size(), actual.size());
         EXPECT_EQ(expected[extension], actual[extension]);
     }


### PR DESCRIPTION
#### 概要
```
cgi_path .rb /usr/bin/ruby;
```
上記の形式で、拡張子と対応するエグゼキュータのパスを指定できるようにした。

参考：#116
