### PR TITLE
bugfix: レスポンスをchunked送信するときにヘッダにTransfer-Encoding:がない。

### DIFF
--- a/src/communication/ResponseDataList.cpp
+++ b/src/communication/ResponseDataList.cpp
@@ -36,22 +36,21 @@ void ResponseDataList::set_mode(t_sending_mode mode) {
 }
 
 // [As IResponseDataConsumer]
+ResponseDataList::t_sending_mode ResponseDataList::determine_sending_mode() {
+    t_sending_mode mode;
+    if (is_injection_closed()) {
+        // オリジネーションが完了している -> chunked送信しない
+        mode = ResponseDataList::SM_NOT_CHUNKED;
+    } else {
+        // オリジネーションが未完了 -> chunked送信する
+        mode = ResponseDataList::SM_CHUNKED;
+    }
+    set_mode(mode);
+    return mode;
+}
 
 void ResponseDataList::start(const HTTP::byte_string &initial_data) {
     // BVOUT(initial_data);
-
-    {
-        t_sending_mode mode;
-        if (is_injection_closed()) {
-            // オリジネーションが完了している -> chunked送信しない
-            mode = ResponseDataList::SM_NOT_CHUNKED;
-        } else {
-            // オリジネーションが未完了 -> chunked送信する
-            mode = ResponseDataList::SM_CHUNKED;
-        }
-        set_mode(mode);
-    }
-
     VOUT(sent_serialized);
     serialized_data = initial_data;
     sent_serialized = 0;

--- a/src/communication/ResponseDataList.hpp
+++ b/src/communication/ResponseDataList.hpp
@@ -25,6 +25,7 @@ public:
 
     ~IResponseDataConsumer() {}
 
+    virtual t_sending_mode determine_sending_mode() = 0;
     // 初期データ与えて送信開始
     virtual void start(const HTTP::byte_string &initial_data) = 0;
 
@@ -97,6 +98,7 @@ public:
     // 可能かつ必要ならバケットを1つ取ってシリアライズする
     void serialize_if_needed();
 
+    t_sending_mode determine_sending_mode();
     // 送信を開始する
     void start(const HTTP::byte_string &initial_data);
 

--- a/src/communication/ResponseHTTP.cpp
+++ b/src/communication/ResponseHTTP.cpp
@@ -45,10 +45,10 @@ HTTP::byte_string ResponseHTTP::serialize_former_part() {
 }
 
 void ResponseHTTP::start() {
-    if (consumer()->get_sending_mode() == ResponseDataList::SM_CHUNKED) {
+    const ResponseDataList::t_sending_mode mode = consumer()->determine_sending_mode();
+    if (mode == ResponseDataList::SM_CHUNKED) {
         feed_header(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked"));
     }
-
     consumer()->start(serialize_former_part());
 }
 


### PR DESCRIPTION
~~#127 待ち。~~

レスポンスをchunked送信する際はヘッダに`Transfer-Encoding:`を追加するのだが、
すでにヘッダをバイト列変換した後に追加していたので無意味だった。