### PR TITLE
ASocketが抱えるソケットにおいてSIGPIPEを発生させないようにする

### DIFF
--- a/src/socket/ASocket.cpp
+++ b/src/socket/ASocket.cpp
@@ -12,8 +12,11 @@ ASocket::ASocket(t_socket_domain sdomain, t_socket_type stype) : port(0) {
     domain = sdomain;
     type   = stype;
 
-    int yes = 1;
+    int yes;
+    yes = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
+    yes = 1;
+    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(t_fd sock_fd, t_socket_domain sdomain, t_socket_type stype) : fd(sock_fd), port(0) {


### PR DESCRIPTION
`siege`を途中で終わらせるとwebservが巻き込まれ落ちしていた。