### PR TITLE
リクエストマッチングの結果をリクエストに反映する

### DIFF
--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -130,6 +130,7 @@ void Connection::perform_receiving(IObserver &observer) {
         rt.start_if_needed();
         bool is_disconnected = rt.inject_data(buf, received_size, extra_data_buffer);
         rt.req()->after_injection(is_disconnected);
+        rt.req()->check_size_limitation();
     }
 }
 

--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -116,7 +116,7 @@ std::ostream &operator<<(std::ostream &ost, const RequestTarget &f) {
 
 RequestHTTP::ParserStatus::ParserStatus() : found_obs_fold(false), is_freezed(false) {}
 
-RequestHTTP::RequestHTTP() : mid(0), rp() {
+RequestHTTP::RequestHTTP() : mid(0), client_max_body_size(0), rp() {
     DXOUT("[create_requedt]");
     this->ps.parse_progress = PP_REQLINE_START;
     this->rp.http_method    = HTTP::METHOD_UNKNOWN;
@@ -753,6 +753,10 @@ RequestHTTP::byte_string RequestHTTP::get_body() const {
 
 RequestHTTP::byte_string RequestHTTP::get_plain_message() const {
     return RequestHTTP::byte_string(bytebuffer.begin(), bytebuffer.begin() + mid);
+}
+
+void RequestHTTP::set_max_body_size(ssize_t size) {
+    client_max_body_size = size;
 }
 
 RequestHTTP::light_string RequestHTTP::freeze() {

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -236,9 +236,12 @@ public:
     // 受信済み(未解釈含む)データサイズ
     size_t receipt_size() const;
     // 解釈済みボディサイズ
+    // 「受信したデータのうち解釈済みのもの」なので、実際のボディサイズとは限らない(特にchunkedの場合は明確に異なる)
     size_t parsed_body_size() const;
     // 解釈済みデータサイズ
     size_t parsed_size() const;
+
+    size_t effective_parsed_body_size() const;
 
     // リクエストのHTTPバージョン
     HTTP::t_version get_http_version() const;
@@ -262,6 +265,10 @@ public:
     bool is_freezed() const;
     // predicate: このリクエストに対するレスポンスを送り終わった後, 接続を維持すべきかどうか
     bool should_keep_in_touch() const;
+
+    // 各種サイズの制限を調べる
+    // 違反していれば対応する例外を投げる(すべてunrecovarable扱い)
+    void check_size_limitation();
 
     header_holder_type::joined_dict_type get_cgi_meta_vars() const;
     const IRequestMatchingParam &get_request_matching_param() const;

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -175,6 +175,7 @@ public:
 private:
     byte_string bytebuffer;
     ssize_t mid;
+    ssize_t client_max_body_size;
 
     // 解析中の情報
     ParserStatus ps;
@@ -250,6 +251,8 @@ public:
     byte_string get_body() const;
     // HTTPメッセージ全文を返す
     byte_string get_plain_message() const;
+
+    void set_max_body_size(ssize_t size);
 
     // predicate: ナビゲーション(ルーティング)できる状態になったかどうか
     bool is_routable() const;

--- a/src/interface/IRouter.hpp
+++ b/src/interface/IRouter.hpp
@@ -3,6 +3,7 @@
 #include "../communication/RequestHTTP.hpp"
 #include "../communication/ResponseHTTP.hpp"
 #include "IOriginator.hpp"
+#include "IRequestMatcher.hpp"
 
 // [ルータインターフェース]
 // [責務]
@@ -11,7 +12,7 @@ class IRouter {
 public:
     virtual ~IRouter(){};
 
-    virtual IOriginator *route(const RequestHTTP &request) = 0;
+    virtual RequestMatchingResult route(const IRequestMatchingParam &request) = 0;
 };
 
 #endif

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -39,9 +39,9 @@ void HTTPServer::init(const std::string &config_path) {
     }
 
     config::Parser parser;
-    const config::config_dict &configs = parser.parse(file::read(config_path));
+    configs_ = parser.parse(file::read(config_path));
 
-    for (config::config_dict::const_iterator it = configs.begin(); it != configs.end(); ++it) {
+    for (config::config_dict::const_iterator it = configs_.begin(); it != configs_.end(); ++it) {
         const config::host_port_pair &hp     = it->first;
         const config::config_vector &configs = it->second;
         this->listen(SD_IP4, ST_TCP, hp.second, configs);

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -19,7 +19,7 @@ RequestMatchingResult MockMatcher::request_match(const std::vector<config::Confi
     result.path_cgi_executor    = HTTP::strfy("/usr/bin/ruby");
     result.status_code          = HTTP::STATUS_MOVED_PERMANENTLY;
     result.redirect_location    = HTTP::strfy("/mmmmm");
-    result.client_max_body_size = 10;
+    result.client_max_body_size = 1024; // 仮
     return result;
 }
 

--- a/src/server/HTTPServer.hpp
+++ b/src/server/HTTPServer.hpp
@@ -39,7 +39,7 @@ public:
     // イベントループ開始
     void run();
 
-    IOriginator *route(const RequestHTTP &request);
+    RequestMatchingResult route(const IRequestMatchingParam &request);
 };
 
 #endif

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -31,10 +31,21 @@ const HTTP::byte_string HTTP::version_str(HTTP::t_version version) {
 
 const HTTP::byte_string HTTP::reason(HTTP::t_status status) {
     switch (status) {
+        // 2**
         case HTTP::STATUS_OK:
             return strfy("OK");
+        // 3**
+        case HTTP::STATUS_MOVED_PERMANENTLY:
+            return strfy("Moved Permanently");
         case HTTP::STATUS_FOUND:
             return strfy("Found");
+        case HTTP::STATUS_NOT_MODIFIED:
+            return strfy("Not Modified");
+        case HTTP::STATUS_TEMPORARY_REDIRECT:
+            return strfy("Temporary Redirect");
+        case HTTP::STATUS_PERMANENT_REDIRECT:
+            return strfy("Permanent Redirect");
+        // 4**
         case HTTP::STATUS_BAD_REQUEST:
             return strfy("Bad Request");
         case HTTP::STATUS_UNAUTHORIZED:
@@ -47,8 +58,15 @@ const HTTP::byte_string HTTP::reason(HTTP::t_status status) {
             return strfy("Method Not Allowed");
         case HTTP::STATUS_TIMEOUT:
             return strfy("Connection Timed out");
+        case HTTP::STATUS_PAYLOAD_TOO_LARGE:
+            return strfy("Payload Too Large");
+        case HTTP::STATUS_URI_TOO_LONG:
+            return strfy("URI Too Long");
         case HTTP::STATUS_IM_A_TEAPOT:
             return strfy("I'm a teapot");
+        case HTTP::STATUS_HEADER_TOO_LARGE:
+            return strfy("Header Too Large");
+        // 5**
         case HTTP::STATUS_INTERNAL_SERVER_ERROR:
             return strfy("Internal Server Error");
         case HTTP::STATUS_NOT_IMPLEMENTED:

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -30,6 +30,7 @@ enum t_status {
     STATUS_NOT_FOUND          = 404,
     STATUS_METHOD_NOT_ALLOWED = 405,
     STATUS_TIMEOUT            = 408,
+    STATUS_PAYLOAD_TOO_LARGE  = 413,
     STATUS_URI_TOO_LONG       = 414,
     STATUS_IM_A_TEAPOT        = 418,
     STATUS_HEADER_TOO_LARGE   = 431,


### PR DESCRIPTION
resolve #155

今のところはクライアントボディサイズ。
ただ、タイムアウトなども変化させられるようにする余地はある。

---

ボディサイズ制限値はルーティングしてみるまでわからないので、
ルーティング後にボディサイズ制限値をリクエストに設定してチェックする。
チェックタイミングは

- ボディサイズ制限値のセット直後
- ソケット受信データの注入直後

チェックに通らなかった場合は回復不能なエラー(413)とする。

---

ボディサイズ制限は**パースしたデータ**のサイズではなく**受信したデータ**のサイズに対して適用する。

両者の差は`Transfer-Encoding:`が設定されている時に意味を持つ。
chunked伝送の場合は `パースしたデータ < 受信したデータ` だし、
その他の圧縮アルゴリズムが使われている場合は `パースしたデータ >= 受信したデータ` かもしれない。
