### PR TITLE
信頼性の高い持続的接続

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME		=	webserv
 CXX			=	c++
-CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic
+CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic -g3 -fsanitize=address
+# CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic
 
 SRC_DIR		=	./src
 SRC_MAIN	=	./src/main.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME		=	webserv
 CXX			=	c++
-CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic -g3 -fsanitize=address
 # CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic
+CXXFLAGS	=	-Wall -Wextra -Werror -std=c++98 --pedantic -g3 -fsanitize=address
 
 SRC_DIR		=	./src
 SRC_MAIN	=	./src/main.cpp

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -2,11 +2,9 @@
 http {
     server {
         listen 80;
-        listen 8080;
         server_name "server1";
         location / {
-            # exec_cgi on;
-            root /Users/corvvs/reps/42cursus/webserv/;
+            root /data/server1/;
             index index.html index.htm;
         }
     }

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -2,9 +2,11 @@
 http {
     server {
         listen 80;
+        listen 8080;
         server_name "server1";
         location / {
-            root /data/server1/;
+            # exec_cgi on;
+            root /Users/corvvs/reps/42cursus/webserv/;
             index index.html index.htm;
         }
     }

--- a/src/Originators.hpp
+++ b/src/Originators.hpp
@@ -4,6 +4,7 @@
 #include "originator/AutoIndexer.hpp"
 #include "originator/CGI.hpp"
 #include "originator/Echoer.hpp"
+#include "originator/ErrorPageGenerator.hpp"
 #include "originator/FileDeleter.hpp"
 #include "originator/FilePoster.hpp"
 #include "originator/FileReader.hpp"

--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -152,14 +152,14 @@ void Connection::detect_update(IObserver &observer) {
             rt.respond();
             observer.reserve_set(this, IObserver::OT_WRITE);
         } else if (rt.is_terminatable()) { // レスポンスを終了できる場合 -> ラウンドトリップ終了
-            rt.wipeout();
-            if (rt.req()->should_keep_in_touch()) {
+            if (rt.req() && rt.req()->should_keep_in_touch()) {
                 DXOUT("KEEP");
                 observer.reserve_unset(this, IObserver::OT_WRITE);
             } else {
                 DXOUT("CLOSE");
                 shutdown_gracefully(observer);
             }
+            rt.wipeout();
         } else {
             break;
         }

--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -22,6 +22,8 @@ ssize_t Connection::NetworkBuffer::receive(SocketConnected &sock) {
     if (read_size > 0) {
         // read_buffer にデータがあるならそれを待避させる
         extra_data_buffer.push_back(read_buffer);
+        read_size = 0;
+        read_buffer.resize(read_size);
         return extra_data_buffer.front().size();
     }
 

--- a/src/communication/Connection.cpp
+++ b/src/communication/Connection.cpp
@@ -111,6 +111,11 @@ void Connection::notify(IObserver &observer, IObserver::observation_category cat
                     assert(false);
             }
             if (!rt.is_freezed() && net_buffer.should_redo()) {
+                // - リクエストが凍結されていない
+                // - NetworkBuffer に余ったデータがある
+                // なら, イベントハンドラをもう一度やり直す.
+                // ただし, イベントを Read に切り替える.
+                // (HTTPパイプライン)
                 cat = IObserver::OT_READ;
                 continue;
             }

--- a/src/communication/Connection.hpp
+++ b/src/communication/Connection.hpp
@@ -42,6 +42,30 @@ public:
         Attribute();
     };
 
+    class NetworkBuffer {
+    public:
+        typedef std::list<byte_string> extra_buffer_type;
+
+    private:
+        byte_string read_buffer;
+        extra_buffer_type extra_data_buffer;
+        ssize_t read_size;
+
+    public:
+        NetworkBuffer();
+
+        // ソケットから内部バッファにデータを受信する
+        ssize_t receive(SocketConnected &sock);
+        // 内部バッファの先頭チャンクを取り出す
+        const byte_string &top_front() const;
+        // 内部バッファの先頭チャンクを除去する
+        void pop_front();
+        // 内部バッファの先頭にデータを追加する
+        void push_front(const light_string &data);
+        // 再実行すべきか
+        bool should_redo() const;
+    };
+
 private:
     Attribute attr;
 
@@ -58,10 +82,7 @@ private:
 
     Lifetime lifetime;
 
-    // 余剰データバッファ
-    // あるリクエストが終端以降のデータを持っている場合, それを受け取って保持しておく
-    // 次のリクエストがきたら, 受信データより優先的にこのデータを使ってリクエストを処理する
-    extra_buffer_type extra_data_buffer;
+    NetworkBuffer net_buffer;
 
     void perform_reaction(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
     void perform_receiving(IObserver &observer);

--- a/src/communication/Connection.hpp
+++ b/src/communication/Connection.hpp
@@ -51,7 +51,11 @@ public:
         // ソケットからのデータが入るバッファ
         byte_string read_buffer;
         // 「余ったデータ」が入るバッファ
-        extra_buffer_type extra_data_buffer;
+        extra_buffer_type extra_buffer;
+        // extra_buffer のサイズ合計
+        size_t extra_amount;
+
+        void check_extra_overflow();
 
     public:
         NetworkBuffer();

--- a/src/communication/Connection.hpp
+++ b/src/communication/Connection.hpp
@@ -47,9 +47,11 @@ public:
         typedef std::list<byte_string> extra_buffer_type;
 
     private:
-        byte_string read_buffer;
-        extra_buffer_type extra_data_buffer;
         ssize_t read_size;
+        // ソケットからのデータが入るバッファ
+        byte_string read_buffer;
+        // 「余ったデータ」が入るバッファ
+        extra_buffer_type extra_data_buffer;
 
     public:
         NetworkBuffer();

--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -778,7 +778,10 @@ RequestHTTP::light_string RequestHTTP::freeze() {
 
 bool RequestHTTP::should_keep_in_touch() const {
     // TODO: 仮実装
-    return false;
+    if (this->rp.connection.close_) {
+        return false;
+    }
+    return true;
 }
 
 RequestHTTP::header_holder_type::joined_dict_type RequestHTTP::get_cgi_meta_vars() const {

--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -773,7 +773,7 @@ RequestHTTP::light_string RequestHTTP::freeze() {
     }
     this->ps.is_freezed = true;
     lifetime.deactivate();
-    return light_string(bytebuffer, mid);
+    return light_string(bytebuffer, this->ps.end_of_body);
 }
 
 bool RequestHTTP::should_keep_in_touch() const {

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -293,6 +293,12 @@ public:
 
     header_holder_type::joined_dict_type get_cgi_meta_vars() const;
     const IRequestMatchingParam &get_request_matching_param() const;
+
+    // 「現在抱えているエラー」を返す.
+    // ** 副作用として「現在抱えているエラー」はOKになる. **
+    minor_error purge_error();
+    // 「現在抱えているエラー」を返す.
+    const minor_error &current_error() const;
 };
 
 #endif

--- a/src/communication/ResponseDataList.cpp
+++ b/src/communication/ResponseDataList.cpp
@@ -11,7 +11,6 @@ ResponseDataList::ResponseDataList() : total(0), sent_serialized(0), sending_mod
 
 void ResponseDataList::inject(const char *src, size_t n, bool is_completed) {
     assert(list.size() > 0);
-    VOUT(is_completed);
 
     ResponseDataBucket &bucket = list.back();
     bucket.buffer.reserve(n);

--- a/src/communication/ResponseHTTP.hpp
+++ b/src/communication/ResponseHTTP.hpp
@@ -22,7 +22,7 @@ public:
 private:
     HTTP::t_version version_;
     HTTP::t_status status_;
-    bool is_error_;
+    minor_error merror;
     Lifetime lifetime;
     // 送信済みマーカー
     size_t sent_size;
@@ -43,8 +43,10 @@ public:
                  HTTP::t_status status,
                  const header_list_type *headers,
                  IResponseDataConsumer *data_consumer);
-    // エラー応答を構築する
-    ResponseHTTP(HTTP::t_version version, http_error error, bool should_close);
+    // unrecovarable エラー応答を構築する
+    ResponseHTTP(HTTP::t_version version, const http_error &error, bool should_close);
+    // recovarable エラー応答を構築する
+    ResponseHTTP(HTTP::t_version version, const minor_error &error, bool should_close);
 
     ~ResponseHTTP();
 

--- a/src/communication/ResponseHTTP.hpp
+++ b/src/communication/ResponseHTTP.hpp
@@ -32,6 +32,7 @@ private:
     byte_string message_text;
     ResponseDataList local_datalist;
     IResponseDataConsumer *data_consumer_;
+    bool should_close_;
 
     IResponseDataConsumer *consumer();
     const IResponseDataConsumer *consumer() const;
@@ -43,7 +44,7 @@ public:
                  const header_list_type *headers,
                  IResponseDataConsumer *data_consumer);
     // エラー応答を構築する
-    ResponseHTTP(HTTP::t_version version, http_error error);
+    ResponseHTTP(HTTP::t_version version, http_error error, bool should_close);
 
     ~ResponseHTTP();
 
@@ -70,11 +71,12 @@ public:
 
     // predicate: メッセージ全体の送信が完了したかどうか
     bool is_complete() const;
-
-    // エラー応答かどうか
+    // predicate: エラー応答かどうか
     bool is_error() const;
-
+    // predicate: タイムアウトしているかどうか
     bool is_timeout(t_time_epoch_ms now) const;
+    // predicate: このレスポンスを送り終わった後, HTTP接続を閉じるべきかどうか
+    bool should_close() const;
 
     static void swap(ResponseHTTP &lhs, ResponseHTTP &rhs);
 };

--- a/src/communication/RoundTrip.cpp
+++ b/src/communication/RoundTrip.cpp
@@ -37,19 +37,10 @@ void RoundTrip::start_if_needed() {
     lifetime.activate();
 }
 
-bool RoundTrip::inject_data(const u8t *received_buffer, ssize_t received_size, extra_buffer_type &extra_buffer) {
-    if (received_buffer != NULL) {
-        start_if_needed();
-        request_->inject_bytestring(received_buffer, received_buffer + received_size);
-        return received_size == 0;
-    } else {
-        assert(extra_buffer.size() > 0);
-        const extra_buffer_type::size_type n = std::min(extra_buffer.size(), (extra_buffer_type::size_type)1024);
-        bool is_disconnected                 = (extra_buffer.size() == n);
-        request_->inject_bytestring(extra_buffer.begin(), extra_buffer.begin() + n);
-        extra_buffer.erase(extra_buffer.begin(), extra_buffer.begin() + n);
-        return is_disconnected;
-    }
+bool RoundTrip::inject_data(const char *received_buffer, ssize_t received_size) {
+    start_if_needed();
+    request_->inject_bytestring(received_buffer, received_buffer + received_size);
+    return received_size == 0;
 }
 
 bool RoundTrip::is_routable() const {

--- a/src/communication/RoundTrip.cpp
+++ b/src/communication/RoundTrip.cpp
@@ -175,7 +175,7 @@ void RoundTrip::respond_error(const http_error &err) {
     DXOUT(err.get_status() << ":" << err.what());
     destroy_response();
     in_error_responding = true;
-    ResponseHTTP *res   = new ResponseHTTP(HTTP::DEFAULT_HTTP_VERSION, err);
+    ResponseHTTP *res   = new ResponseHTTP(HTTP::DEFAULT_HTTP_VERSION, err, true);
     res->start();
     response_ = res;
 }

--- a/src/communication/RoundTrip.cpp
+++ b/src/communication/RoundTrip.cpp
@@ -81,7 +81,7 @@ void RoundTrip::route(Connection &connection) {
     assert(request_ != NULL);
     reroute_count += 1;
     const RequestMatchingResult result = router.route(request_->get_request_matching_param(), configs_);
-    if (request_->current_error().is_error() || true) {
+    if (request_->current_error().is_error()) {
         // TODO: リクエストがエラーを抱えている場合にエラーレスポンスを作る
         const minor_error me = request_->purge_error();
         originator_          = new ErrorPageGenerator(me, result);

--- a/src/communication/RoundTrip.cpp
+++ b/src/communication/RoundTrip.cpp
@@ -221,3 +221,11 @@ void RoundTrip::destroy_response() {
     delete response_;
     response_ = NULL;
 }
+
+void RoundTrip::emit_fatal_error() {
+    // レスポンスがすでに存在する状態でリクエストがエラーを抱えているなら,
+    // それを http_error に変えて送出
+    if (response_ != NULL && request_ != NULL && request_->current_error().is_error()) {
+        throw http_error(request_->purge_error());
+    }
+}

--- a/src/communication/RoundTrip.hpp
+++ b/src/communication/RoundTrip.hpp
@@ -87,7 +87,7 @@ public:
     // そうでないなら extra_buffer の先頭から一定量が注入される.
     // (この時, extra_buffer が空であってはならない)
     // 接続が閉じたとみられるかどうかを返す
-    bool inject_data(const u8t *received_buffer, ssize_t received_size, extra_buffer_type &extra_buffer);
+    bool inject_data(const char *received_buffer, ssize_t received_size);
 
     void notify_originator(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
 

--- a/src/communication/RoundTrip.hpp
+++ b/src/communication/RoundTrip.hpp
@@ -106,6 +106,8 @@ public:
 
     // 構成要素全てをdeleteし, 初期状態に戻す.
     void wipeout();
+    // 回復不可能なエラーを抱えているなら例外にして投げる
+    void emit_fatal_error();
 };
 
 #endif

--- a/src/communication/RoundTrip.hpp
+++ b/src/communication/RoundTrip.hpp
@@ -75,11 +75,10 @@ public:
     bool is_terminatable() const;
     // predicate: レスポンスを送信中か
     bool is_responding() const;
-
-    // タイムアウトしているかどうか
+    // predicate: タイムアウトしているかどうか
     bool is_timeout(t_time_epoch_ms now) const;
 
-    // predicate: ラウンドトリップがリクエストを持っていないならリクエストを作成する
+    // ラウンドトリップがリクエストを持っていないならリクエストを作成する
     void start_if_needed();
 
     // データを注入する
@@ -95,8 +94,7 @@ public:
     void route(Connection &connection);
     // オリジネーションを開始する
     void originate(IObserver &observer);
-    // リクエストを凍結, つまりデータの注入を受け付けなくする.
-    // 余ったデータを返す
+    // リクエストを凍結, つまりデータの注入を受け付けなくし, 余ったデータを返す.
     light_string freeze_request();
     // 再ルーティングを行う
     void reroute(Connection &connection);

--- a/src/communication/ValidatorHTTP.cpp
+++ b/src/communication/ValidatorHTTP.cpp
@@ -3,7 +3,9 @@
 
 bool HTTP::Validator::is_valid_header_host(const light_string &str) {
     // host = uri-host [ ":" port ]
-
+    if (str.size() == 0) {
+        return false;
+    }
     const light_string::size_type ket = str.find_last_of("]");
     const light_string port_part      = (ket == npos) ? str : str.substr(ket + 1);
     light_string::size_type sep       = port_part.find_last_of(":");

--- a/src/originator/ErrorPageGenerator.cpp
+++ b/src/originator/ErrorPageGenerator.cpp
@@ -1,0 +1,84 @@
+#include "ErrorPageGenerator.hpp"
+#include <unistd.h>
+
+ErrorPageGenerator::ErrorPageGenerator(const minor_error &err, const RequestMatchingResult &match_result)
+    : FileReader(match_result), error(err) {
+    const RequestMatchingResult::status_dict_type dict          = match_result.status_page_dict;
+    RequestMatchingResult::status_dict_type::const_iterator res = dict.find(err.status_code());
+    if (res != dict.end()) {
+        // エラーページ定義があった
+        file_path_ = HTTP::restrfy(res->second);
+    } else {
+        file_path_.clear();
+    }
+}
+
+ErrorPageGenerator::~ErrorPageGenerator() {}
+
+void ErrorPageGenerator::generate_html() {
+    if (originated_) {
+        return;
+    }
+
+    // 出力データ生成
+    response_data.inject(HTTP::strfy("<html>\n"), false);
+    response_data.inject(HTTP::strfy("<head>\n"), false);
+    response_data.inject(HTTP::strfy("<title>webserv error</title>\n"), false);
+
+    // common header
+
+    response_data.inject(HTTP::strfy("</head>\n"), false);
+    response_data.inject(HTTP::strfy("<body>\n"), false);
+
+    // page header
+
+    response_data.inject(HTTP::strfy("<h3>\n"), false);
+    response_data.inject(ParserHelper::utos(error.status_code(), 10), false);
+    response_data.inject(HTTP::strfy(": "), false);
+    if (error.message().empty()) {
+        response_data.inject(HTTP::reason(error.status_code()), false);
+    } else {
+        response_data.inject(HTTP::strfy(error.message()), false);
+    }
+    response_data.inject(HTTP::strfy("</h3>\n"), false);
+
+    // page footer
+
+    response_data.inject(HTTP::strfy("</body>\n"), false);
+    response_data.inject(HTTP::strfy("</html>\n"), false);
+    response_data.inject("", 0, true);
+    originated_ = true;
+}
+
+void ErrorPageGenerator::start_origination(IObserver &observer) {
+    (void)observer;
+    if (file_path_.size() > 0) {
+        read_from_file();
+    } else {
+        // 簡易ページ生成
+        generate_html();
+    }
+}
+
+void ErrorPageGenerator::leave() {
+    delete this;
+}
+
+ResponseHTTP *ErrorPageGenerator::respond(const RequestHTTP &request) {
+    ResponseHTTP::header_list_type headers;
+    IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
+    switch (sm) {
+        case ResponseDataList::SM_CHUNKED:
+            headers.push_back(std::make_pair(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked")));
+            break;
+        case ResponseDataList::SM_NOT_CHUNKED:
+            headers.push_back(
+                std::make_pair(HeaderHTTP::content_length, ParserHelper::utos(response_data.current_total_size(), 10)));
+            break;
+        default:
+            break;
+    }
+    ResponseHTTP *res = new ResponseHTTP(request.get_http_version(), error.status_code(), &headers, &response_data);
+    res->start();
+    return res;
+}

--- a/src/originator/ErrorPageGenerator.hpp
+++ b/src/originator/ErrorPageGenerator.hpp
@@ -1,0 +1,26 @@
+#ifndef ERROR_PAGE_GENERATOR_HPP
+#define ERROR_PAGE_GENERATOR_HPP
+#include "FileReader.hpp"
+
+class ErrorPageGenerator : public FileReader {
+public:
+    typedef HTTP::byte_string byte_string;
+    typedef HTTP::char_string char_string;
+    typedef HTTP::light_string light_string;
+    typedef byte_string::size_type size_type;
+
+private:
+    minor_error error;
+
+    void generate_html();
+
+public:
+    ErrorPageGenerator(const minor_error &error, const RequestMatchingResult &match_result);
+    ~ErrorPageGenerator();
+
+    void start_origination(IObserver &observer);
+    void leave();
+    ResponseHTTP *respond(const RequestHTTP &request);
+};
+
+#endif

--- a/src/originator/FileReader.hpp
+++ b/src/originator/FileReader.hpp
@@ -13,7 +13,7 @@ public:
     typedef HTTP::light_string light_string;
     typedef byte_string::size_type size_type;
 
-private:
+protected:
     char_string file_path_;
     bool originated_;
     ResponseDataList response_data;
@@ -25,15 +25,15 @@ public:
     FileReader(const RequestMatchingResult &match_result);
     ~FileReader();
 
-    void notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
-    void inject_socketlike(ISocketLike *socket_like);
-    bool is_originatable() const;
-    bool is_reroutable() const;
-    bool is_responsive() const;
-    bool is_origination_started() const;
-    void start_origination(IObserver &observer);
-    void leave();
-    ResponseHTTP *respond(const RequestHTTP &request);
+    virtual void notify(IObserver &observer, IObserver::observation_category cat, t_time_epoch_ms epoch);
+    virtual void inject_socketlike(ISocketLike *socket_like);
+    virtual bool is_originatable() const;
+    virtual bool is_reroutable() const;
+    virtual bool is_responsive() const;
+    virtual bool is_origination_started() const;
+    virtual void start_origination(IObserver &observer);
+    virtual void leave();
+    virtual ResponseHTTP *respond(const RequestHTTP &request);
 };
 
 #endif

--- a/src/utils/HTTPError.cpp
+++ b/src/utils/HTTPError.cpp
@@ -4,6 +4,8 @@
 
 http_error::http_error(const char *_Message, HTTP::t_status status) : runtime_error(_Message), status_(status) {}
 
+http_error::http_error(const minor_error &minor) : runtime_error(minor.message()), status_(minor.status_code()) {}
+
 HTTP::t_status http_error::get_status() const {
     return status_;
 }

--- a/src/utils/HTTPError.hpp
+++ b/src/utils/HTTPError.hpp
@@ -6,19 +6,6 @@
 #include <stdexcept>
 #include <utility>
 
-// [回復不能なHTTPエラー例外クラス]
-// 「回復不能なHTTPエラー」が発生した場合,
-// クライアントには即座にHTTPエラー応答を送信し, その後HTTP接続を切る.
-class http_error : public std::runtime_error {
-private:
-    HTTP::t_status status_;
-
-public:
-    http_error(const char *_Message, HTTP::t_status status);
-
-    HTTP::t_status get_status() const;
-};
-
 // [軽微なHTTPエラークラス]
 // 即例外を出すほどではないが, 最終的にはエラー応答を返すようなエラー.
 class minor_error : public std::pair<std::string, HTTP::t_status> {
@@ -43,5 +30,19 @@ std::ostream &operator<<(std::ostream &ost, const minor_error &f);
 // 2つの引数のうち, 左側がエラーなら左側を, そうでないなら右側を返す.
 // (確実に短絡評価させないために関数にしている)
 const minor_error &erroneous(const minor_error &e1, const minor_error &e2);
+
+// [回復不能なHTTPエラー例外クラス]
+// 「回復不能なHTTPエラー」が発生した場合,
+// クライアントには即座にHTTPエラー応答を送信し, その後HTTP接続を切る.
+class http_error : public std::runtime_error {
+private:
+    HTTP::t_status status_;
+
+public:
+    http_error(const char *_Message, HTTP::t_status status);
+    http_error(const minor_error &minor);
+
+    HTTP::t_status get_status() const;
+};
 
 #endif

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -90,9 +90,9 @@ public:
         if (!base || first == last) {
             return HTTP::strfy("");
         }
-        // QVOUT(*base);
-        // VOUT(first);
-        // VOUT(last);
+        if (first == 0 && last == base->size()) {
+            return *base;
+        }
         return string_class(base->begin() + first, base->begin() + last);
     }
 

--- a/test_case/validator_http.cpp
+++ b/test_case/validator_http.cpp
@@ -4,6 +4,9 @@
 #define LS(c_str) (HTTP::light_string(HTTP::strfy(c_str)))
 
 // [is_valid_header_host]
+TEST(is_valid_header_host, basic) {
+    EXPECT_FALSE(HTTP::Validator::is_valid_header_host(LS("")));
+}
 
 // [is_uri_host]
 


### PR DESCRIPTION
resolve #85

### fee0c8cbed934e1ef9bba45074a7a7b24d760550
- レスポンス送信後, コネクションがアイドル状態でタイムアウトになると落ちる件。
- `delete`後のオブジェクトのメンバ関数を読んでいたり、NULLポインタ経由でメンバ関数を読んでいたりした。

### 持続的接続

`curl -v http://localhost:80/ --next http://localhost:80/`で「接続が再利用されてますよ」的な表示が出ればOK.
ただし200が返ってくるリクエストである必要がある。

### HTTPパイプライン

`telnet`でリクエストを2つ繋げて一気に送る。
2つ分のレスポンスが一気に返って来ればOK。

### 回復可能なエラー

Issue参照
リクエストマッチング側の修正を待つ必要がある。
