### PR TITLE
#174 CGIのパスの分割

### DIFF
--- a/src/interface/IRequestMatcher.hpp
+++ b/src/interface/IRequestMatcher.hpp
@@ -20,7 +20,21 @@ struct RequestMatchingResult {
         RT_ECHO
     };
 
+    /**
+     * リクエスト: `/cgi-bin/cgi.rb/pathinfo`
+     * root       : /cgi-bin
+     * cgi_script : /cgi.rb
+     * path_info  : /pathinfo
+     */
+    struct CgiResource {
+        HTTP::byte_string root;
+        HTTP::byte_string script_name;
+        HTTP::byte_string path_info;
+    };
+
     const RequestTarget *target;
+
+    CgiResource cgi_resource;
 
     // 種別
     ResultType result_type;
@@ -29,12 +43,7 @@ struct RequestMatchingResult {
     bool is_executable;
 
     // リクエストターゲットにマッチしたローカルファイルのパス
-    // CGIでいう`SCRIPT_NAME`に相当
     HTTP::byte_string path_local;
-
-    // リクエストターゲットのうちファイルパスにマッチするパートより後の部分
-    // CGIでいう`PATH_INFO`に相当
-    HTTP::byte_string path_after;
 
     // リクエスト先がCGIである場合、かつエグゼキュータが特定できた場合、エグゼキュータのパスが入る。
     HTTP::byte_string path_cgi_executor;

--- a/src/interface/IRequestMatcher.hpp
+++ b/src/interface/IRequestMatcher.hpp
@@ -26,7 +26,7 @@ struct RequestMatchingResult {
      * cgi_script : /cgi.rb
      * path_info  : /pathinfo
      */
-    struct CgiResource {
+    struct CGIResource {
         HTTP::byte_string root;
         HTTP::byte_string script_name;
         HTTP::byte_string path_info;
@@ -34,7 +34,7 @@ struct RequestMatchingResult {
 
     const RequestTarget *target;
 
-    CgiResource cgi_resource;
+    CGIResource cgi_resource;
 
     // 種別
     ResultType result_type;

--- a/src/originator/CGI.cpp
+++ b/src/originator/CGI.cpp
@@ -28,7 +28,7 @@ CGI::Attribute::Attribute(const RequestMatchingResult &matching_result,
                           const ICGIConfigurationProvider &configuration_provider)
     : configuration_provider_(configuration_provider)
     , executor_path_(matching_result.path_cgi_executor)
-    , script_path_(matching_result.path_local)
+    , script_path_(matching_result.cgi_resource.root + matching_result.cgi_resource.script_name)
     , query_string_(configuration_provider.get_request_matching_param().get_request_target().query.str())
     , observer(NULL)
     , master(NULL)

--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -44,13 +44,48 @@ RequestMatchingResult RequestMatcher::request_match(const std::vector<config::Co
 
 RequestMatchingResult
 RequestMatcher::routing_cgi(RequestMatchingResult res, const RequestTarget &target, const config::Config &conf) {
-    cgi_resource_pair resource;
-    resource              = get_cgi_resource(target, conf);
-    res.path_local        = resource.first;
-    res.path_after        = resource.second;
+    res.cgi_resource      = make_cgi_resource(target, conf);
     res.path_cgi_executor = get_path_cgi_executor(target, conf, res.path_local);
     res.result_type       = RequestMatchingResult::RT_CGI;
     return res;
+}
+
+/**
+ * 以下の形式でパスを分割する
+ * リクエスト: `/cgi-bin/cgi.rb/pathinfo`
+ * root       : /cgi-bin
+ * cgi_script : /cgi.rb
+ * path_info  : /pathinfo
+ */
+RequestMatchingResult::CgiResource RequestMatcher::make_cgi_resource(const RequestTarget &target,
+                                                                     const config::Config &conf) const {
+    const std::string root = conf.get_root(HTTP::restrfy(target.path.str()));
+    // ルートとパスをくっつける
+    const HTTP::byte_string full_path = HTTP::Utils::join_path(HTTP::strfy(root), target.path.str());
+    const light_string path           = full_path;
+
+    RequestMatchingResult::CgiResource resource;
+    size_t before_idx = root.size();
+    for (size_t i = root.size();; i = path.find("/", i)) {
+        HTTP::byte_string cur = path.substr(0, i).str();
+        if (file::is_file(HTTP::restrfy(cur))) {
+            resource.root        = path.substr(0, before_idx).str();
+            resource.script_name = path.substr(before_idx, i - before_idx).str();
+            if (i != HTTP::npos) {
+                resource.path_info = path.substr(i, path.size()).str();
+            }
+            break;
+        }
+        if (i == HTTP::npos) {
+            break;
+        }
+        before_idx = i;
+        i += 1;
+    }
+    if (resource.script_name.empty()) {
+        throw http_error("file not found", HTTP::STATUS_NOT_FOUND);
+    }
+    return resource;
 }
 
 RequestMatchingResult RequestMatcher::routing_default(RequestMatchingResult res,
@@ -195,36 +230,6 @@ RequestMatcher::redirect_pair RequestMatcher::get_redirect(const RequestTarget &
     const std::string &path                         = HTTP::restrfy(target.path.str());
     std::pair<HTTP::t_status, std::string> redirect = conf.get_redirect(path);
     return std::make_pair(redirect.first, HTTP::strfy(redirect.second));
-}
-
-// ファイルの権限を順番に見ていき、ファイルが存在した時点で、分割する
-RequestMatcher::cgi_resource_pair RequestMatcher::get_cgi_resource(const RequestTarget &target,
-                                                                   const config::Config &conf) const {
-    HTTP::byte_string resource_path;
-    HTTP::byte_string path_info;
-    const std::string root = conf.get_root(HTTP::restrfy(target.path.str()));
-    // ルートとパスをくっつける
-    HTTP::byte_string full_path = HTTP::Utils::join_path(HTTP::strfy(root), target.path.str());
-    light_string path           = full_path;
-    // ルート部分の末尾から見ていく
-    for (size_t i = root.size();; i = path.find("/", i)) {
-        HTTP::byte_string cur = path.substr(0, i).str();
-        if (file::is_file(HTTP::restrfy(cur))) {
-            resource_path = cur;
-            if (i != HTTP::npos) {
-                path_info = path.substr(i, path.size()).str();
-            }
-            break;
-        }
-        if (i == HTTP::npos) {
-            break;
-        }
-        i += 1;
-    }
-    if (resource_path.empty()) {
-        throw http_error("file not found", HTTP::STATUS_NOT_FOUND);
-    }
-    return std::make_pair(resource_path, path_info);
 }
 
 RequestMatchingResult::status_dict_type RequestMatcher::get_status_page_dict(const RequestTarget &target,

--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -57,14 +57,14 @@ RequestMatcher::routing_cgi(RequestMatchingResult res, const RequestTarget &targ
  * cgi_script : /cgi.rb
  * path_info  : /pathinfo
  */
-RequestMatchingResult::CgiResource RequestMatcher::make_cgi_resource(const RequestTarget &target,
+RequestMatchingResult::CGIResource RequestMatcher::make_cgi_resource(const RequestTarget &target,
                                                                      const config::Config &conf) const {
     const std::string root = conf.get_root(HTTP::restrfy(target.path.str()));
     // ルートとパスをくっつける
     const HTTP::byte_string full_path = HTTP::Utils::join_path(HTTP::strfy(root), target.path.str());
     const light_string path           = full_path;
 
-    RequestMatchingResult::CgiResource resource;
+    RequestMatchingResult::CGIResource resource;
     size_t before_idx = root.size();
     for (size_t i = root.size();; i = path.find("/", i)) {
         HTTP::byte_string cur = path.substr(0, i).str();

--- a/src/router/RequestMatcher.hpp
+++ b/src/router/RequestMatcher.hpp
@@ -44,7 +44,7 @@ private:
                                             const config::Config &conf,
                                             const HTTP::byte_string &cgi_path) const;
 
-    RequestMatchingResult::CgiResource make_cgi_resource(const RequestTarget &target, const config::Config &conf) const;
+    RequestMatchingResult::CGIResource make_cgi_resource(const RequestTarget &target, const config::Config &conf) const;
     HTTP::byte_string make_resource_path(const RequestTarget &target, const config::Config &conf) const;
 };
 

--- a/src/router/RequestMatcher.hpp
+++ b/src/router/RequestMatcher.hpp
@@ -7,7 +7,6 @@
 class RequestMatcher : public IRequestMatcher {
 public:
     typedef HTTP::light_string light_string;
-    typedef std::pair<HTTP::byte_string, HTTP::byte_string> cgi_resource_pair;
     typedef std::pair<HTTP::t_status, HTTP::byte_string> redirect_pair;
 
 public:
@@ -39,13 +38,13 @@ private:
 
     long get_client_max_body_size(const RequestTarget &target, const config::Config &conf) const;
     redirect_pair get_redirect(const RequestTarget &target, const config::Config &conf) const;
-    cgi_resource_pair get_cgi_resource(const RequestTarget &target, const config::Config &conf) const;
     RequestMatchingResult::status_dict_type get_status_page_dict(const RequestTarget &target,
                                                                  const config::Config &conf) const;
     HTTP::byte_string get_path_cgi_executor(const RequestTarget &target,
                                             const config::Config &conf,
                                             const HTTP::byte_string &cgi_path) const;
 
+    RequestMatchingResult::CgiResource make_cgi_resource(const RequestTarget &target, const config::Config &conf) const;
     HTTP::byte_string make_resource_path(const RequestTarget &target, const config::Config &conf) const;
 };
 

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -18,7 +18,6 @@ RequestMatchingResult MockMatcher::request_match(const std::vector<config::Confi
     }
     result.target               = &param.get_request_target();
     result.path_local           = HTTP::strfy(".") + param.get_request_target().path.str();
-    result.path_after           = HTTP::strfy("");
     result.path_cgi_executor    = HTTP::strfy("/usr/bin/ruby");
     result.status_code          = HTTP::STATUS_MOVED_PERMANENTLY;
     result.redirect_location    = HTTP::strfy("/mmmmm");

--- a/test_case/config/original_directive.cpp
+++ b/test_case/config/original_directive.cpp
@@ -137,8 +137,9 @@ http { \
         RequestMatchingResult res;
         EXPECT_NO_THROW({
             res = rm.request_match(configs[hp], tp);
-            EXPECT_GT(res.path_local.size(), 0);
-            EXPECT_EQ(res.path_after, HTTP::strfy(""));
+            EXPECT_EQ(HTTP::strfy("./cgi/ruby"), res.cgi_resource.root);
+            EXPECT_EQ(HTTP::strfy("/blank.rb"), res.cgi_resource.script_name);
+            EXPECT_EQ(HTTP::strfy(""), res.cgi_resource.path_info);
         });
     }
 
@@ -147,8 +148,9 @@ http { \
         RequestMatchingResult res;
         EXPECT_NO_THROW({
             res = rm.request_match(configs[hp], tp);
-            EXPECT_GT(res.path_local.size(), 0);
-            EXPECT_EQ(res.path_after, HTTP::strfy("/path/after"));
+            EXPECT_EQ(HTTP::strfy("./cgi/ruby"), res.cgi_resource.root);
+            EXPECT_EQ(HTTP::strfy("/blank.rb"), res.cgi_resource.script_name);
+            EXPECT_EQ(HTTP::strfy("/path/after"), res.cgi_resource.path_info);
         });
     }
 }

--- a/test_case/config/request_matcher.cpp
+++ b/test_case/config/request_matcher.cpp
@@ -47,7 +47,6 @@ http { \
         EXPECT_NO_THROW({
             const RequestMatchingResult res = rm.request_match(configs[hp], tp);
             EXPECT_EQ(HTTP::strfy("./error_page/404.html"), res.path_local);
-            EXPECT_EQ(HTTP::strfy(""), res.path_after);
         });
     }
 
@@ -56,7 +55,6 @@ http { \
         EXPECT_NO_THROW({
             const RequestMatchingResult res = rm.request_match(configs[hp], tp);
             EXPECT_EQ(HTTP::strfy("./error_page/405.html"), res.path_local);
-            EXPECT_EQ(HTTP::strfy(""), res.path_after);
         });
     }
 
@@ -65,7 +63,6 @@ http { \
         EXPECT_NO_THROW({
             const RequestMatchingResult res = rm.request_match(configs[hp], tp);
             EXPECT_EQ(HTTP::strfy("./error_page/500.html"), res.path_local);
-            EXPECT_EQ(HTTP::strfy(""), res.path_after);
         });
     }
 }


### PR DESCRIPTION
#### 概要
resolve #174 
CGIスクリプトのパスを `script_name` と `root` で分割して管理するようにした。
CGIリソースを管理する構造体を作成している。

サンプル
```c++
    /**
     * リクエスト: `/cgi-bin/cgi.rb/pathinfo`
     * root       : /cgi-bin
     * cgi_script : /cgi.rb
     * path_info  : /pathinfo
     */
```