### PR TITLE
parserのテスト追加 + 空のファイルのバリデーション

### DIFF
--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -42,6 +42,9 @@ Parser::DirectiveFunctionsMap Parser::setting_directive_functions(void) {
 }
 
 std::map<host_port_pair, config_vector> Parser::parse(const std::string &file_data) {
+    if (file_data.empty()) {
+        throw SyntaxError("config: file is empty");
+    }
     lexer_.tokenize(file_data);
 
     ErrorMsg err;

--- a/src/config/Validator.cpp
+++ b/src/config/Validator.cpp
@@ -249,11 +249,6 @@ bool is_correct_number_of_args(Directive dire, int mask) {
         return true;
     }
 
-    // 引数の数が0以上か
-    if ((mask & ANY) != 0) {
-        return true;
-    }
-
     // 引数の数が1以上か
     if ((mask & MORE1) != 0 && dire.args.size() >= 1) {
         return true;

--- a/src/config/Validator.hpp
+++ b/src/config/Validator.hpp
@@ -1,5 +1,5 @@
-#ifndef ANALYZER_HPP
-#define ANALYZER_HPP
+#ifndef VALIDATOR_HPP
+#define VALIDATOR_HPP
 #include "Parser.hpp"
 #include <map>
 #include <string>
@@ -10,7 +10,7 @@ namespace config {
 typedef std::string ErrorMsg;
 class SyntaxError : public std::runtime_error {
 public:
-    SyntaxError(void) : std::runtime_error("config: validation error") {}
+    SyntaxError(void) : std::runtime_error("validation error") {}
     SyntaxError(const std::string &what) : std::runtime_error(what) {}
 };
 
@@ -39,10 +39,8 @@ std::string validation_error(const std::string &message, const size_t &line, con
 const unsigned int NOARGS = 0x00000001; // 0 args
 const unsigned int TAKE1  = 0x00000002; // 1 args
 const unsigned int TAKE2  = 0x00000004; // 2 args
-const unsigned int TAKE3  = 0x00000008; // 3 args
 const unsigned int BLOCK  = 0x00000100; // followed by block
 const unsigned int FLAG   = 0x00000200; // 'on' or 'off'
-const unsigned int ANY    = 0x00000400; // >=0 args
 const unsigned int MORE1  = 0x00000800; // >=1 args
 const unsigned int MORE2  = 0x00001000; // >=2 args
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "server/HTTPServer.hpp"
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
 
-void assert_sizeoftype() {
+static void assert_sizeoftype() {
     BUILD_BUG_ON(sizeof(u8t) != 1);
     BUILD_BUG_ON(sizeof(u16t) != 2);
     BUILD_BUG_ON(sizeof(u32t) != 4);
@@ -14,27 +14,23 @@ void assert_sizeoftype() {
 int main(int argc, char **argv) {
     assert_sizeoftype();
 
+    if (argc == 3 && strcmp(argv[1], "-t") == 0) {
+        return HTTPServer::test_configuration(argv[2]);
+    }
+
     if (argc > 2) {
-        std::cerr << "Usage: ./webserv [config_path]" << std::endl;
+        std::cerr << "Usage: ./webserv [filename] [-t filename]" << std::endl;
         return EXIT_FAILURE;
     }
-    const std::string &config_path = (argc == 2) ? argv[1] : "./conf/default.conf";
+    const std::string &conf_path = (argc == 2) ? argv[1] : "./conf/default.conf";
 
-    // HTTPServer  http_server(new EventKqueueLoop());
+    // HTTPServer http_server(new EventKqueueLoop());
+    // HTTPServer http_server(new EventSelectLoop());
     HTTPServer http_server(new EventPollLoop());
-    // HTTPServer  http_server(new EventSelectLoop());
-
-    // conf群の流れ Channel -> Connection -> RoundTrip -> IRouter
-
     try {
-        http_server.init(config_path);
+        http_server.init(conf_path);
         http_server.run();
     } catch (const std::exception &e) {
         std::cerr << "Error: " << e.what() << std::endl;
     }
-    // http_server.listen(SD_IP4, ST_TCP, 8080);
-    // http_server.listen(SD_IP4, ST_TCP, 8081);
-    // http_server.listen(SD_IP4, ST_TCP, 8082);
-    // http_server.listen(SD_IP4, ST_TCP, 8083);
-    // http_server.listen(SD_IP4, ST_TCP, 8084);
 }

--- a/src/server/HTTPServer.hpp
+++ b/src/server/HTTPServer.hpp
@@ -4,14 +4,9 @@
 #include "../Originators.hpp"
 #include "../communication/Channel.hpp"
 #include "../config/Config.hpp"
+#include "../config/Validator.hpp"
 #include "../utils/FileCacher.hpp"
 #include <map>
-
-class MockMatcher : public IRequestMatcher {
-public:
-    RequestMatchingResult request_match(const std::vector<config::Config> &configs,
-                                        const IRequestMatchingParam &request);
-};
 
 // [サーバクラス]
 // [責務]
@@ -29,8 +24,6 @@ private:
     channel_map channels;
     config::config_dict configs_;
 
-    MockMatcher mock_matcher;
-
 public:
     HTTPServer(IObserver *observer);
 
@@ -45,6 +38,8 @@ public:
     void run();
 
     RequestMatchingResult route(const IRequestMatchingParam &request, const config::config_vector &configs);
+
+    static int test_configuration(const std::string &path);
 
 private:
     void listen(t_socket_domain sdomain,

--- a/test_case/config/parse.cpp
+++ b/test_case/config/parse.cpp
@@ -1,0 +1,195 @@
+#include "../../src/config/Parser.hpp"
+#include "../../src/config/Validator.hpp"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <vector>
+
+namespace {
+
+TEST(parse_test, valid_case) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        location / { \
+            return 200 'OK'; \
+        } \
+    } \
+} \
+";
+
+    config::Parser parser;
+    EXPECT_NO_THROW(parser.parse(data));
+}
+
+TEST(parse_test, empty) {
+    const std::string data = "";
+
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// `}` が余分にある
+TEST(parse_test, unexpected_brace) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name server1; \
+        location / { \
+            root / data / server1 / ; \
+            index index.html index.htm; \
+        } \
+    } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// `}` が足りない
+TEST(parse_test, unexpected_eof) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name server1; \
+        location / { \
+            root / data / server1 / ; \
+            index index.html index.htm; \
+        } \
+    } \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// `#` の後ろに文字が存在する場合はコメントとして扱われない
+TEST(parse_test, wrong_comment) {
+    const std::string data = "\
+http { \
+    server { \
+        li#sten 80; \
+        server_name server1; \
+        location / { \
+            root /data/server1/; \
+            index index.html index.htm; \
+        } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// `"` の後ろに文字が存在する場合はクォートして扱われない
+TEST(parse_test, wrong_quote) {
+    const std::string data = "\
+http { \
+    server { \
+        li\"sten 80; \
+        server_name server1; \
+        location / { \
+            root /data/server1/; \
+            index index.html index.htm; \
+        } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// クォートが閉じられていない
+TEST(parse_test, unclosed_literal) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name \"server1; \
+        location / { \
+            root /data/server1/; \
+            index index.html index.htm; \
+        } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// server_nameをhttpコンテキストに設置できない
+TEST(parse_test, not_allowed) {
+    const std::string data = "\
+http { \
+    server_name server1; \
+    server { \
+        listen 80; \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// serverディレクティブの後に `{` が続いていない
+TEST(parse_test, no_opening) {
+    const std::string data = "\
+http { \
+    server; \
+        listen 80; \
+        server_name server1; \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// listenディレクティブが `;` で終端されていない
+TEST(parse_test, not_terminated) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80 \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// auto_indexの引数が `on` or `off` 以外
+TEST(parse_test, not_on_off) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name server1; \
+        location / { \
+            autoindex true; \
+        } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+
+// rootの引数が多い
+TEST(parse_test, invalid_number_of_args) {
+    const std::string data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name server1; \
+        location / { \
+            root /data/server1/ /hoge/; \
+        } \
+    } \
+} \
+";
+    config::Parser parser;
+    EXPECT_THROW(parser.parse(data), config::SyntaxError);
+}
+} // namespace


### PR DESCRIPTION
#### やったこと

- 空のファイルをparserで弾くようにした
- パーサーのバリデーションテストを追加した
- `./webserv [-t filename]` で configの文法チェックを走らせるようにした

resolve #201 , resolve #202 