### PR TITLE
#204 confのエラーページを使うよう修正 + デフォルトのエラーページを定義

### DIFF
--- a/src/communication/RoundTrip.hpp
+++ b/src/communication/RoundTrip.hpp
@@ -44,6 +44,10 @@ private:
     // エラーレスポンス中かどうか
     bool in_error_responding;
 
+    // あるHTTPステータスの時はこのファイルの中身を返す, という時の
+    // ステータスとファイルパスの辞書.
+    RequestMatchingResult::status_dict_type status_page_dict_;
+
     // オリジネーターを生成する
     IOriginator *make_originator(const RequestMatchingResult &result, const RequestHTTP &request);
     void destroy_request();

--- a/src/config/Context.cpp
+++ b/src/config/Context.cpp
@@ -6,17 +6,30 @@ namespace config {
 static cgi_executer_map setup_executer_map();
 static const cgi_executer_map default_executers = setup_executer_map();
 
-ContextMain::ContextMain(void) {
+static std::map<HTTP::t_status, std::string> setup_default_error_pages() {
+    std::map<HTTP::t_status, std::string> error_pages;
+    error_pages[HTTP::STATUS_NOT_FOUND]             = "./error_page/404.html";
+    error_pages[HTTP::STATUS_METHOD_NOT_ALLOWED]    = "./error_page/405.html";
+    error_pages[HTTP::STATUS_INTERNAL_SERVER_ERROR] = "./error_page/500.html";
+    return error_pages;
+}
+
+ContextMain::ContextMain() {
     client_max_body_size = 1024;
     autoindex            = false;
+    error_pages          = setup_default_error_pages();
 }
-ContextMain::~ContextMain(void) {}
+ContextMain::~ContextMain() {}
 
-ContextServer::ContextServer(void) : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")) {}
-ContextServer::~ContextServer(void) {}
+ContextServer::ContextServer() : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")) {
+    error_pages = setup_default_error_pages();
+}
+ContextServer::~ContextServer() {}
 
-ContextLocation::ContextLocation(void)
-    : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")), cgi_executers(default_executers) {}
+ContextLocation::ContextLocation()
+    : redirect(std::make_pair(REDIRECT_INITIAL_VALUE, "")), cgi_executers(default_executers) {
+    error_pages = setup_default_error_pages();
+}
 
 ContextLocation::ContextLocation(const ContextServer &server) {
     client_max_body_size = server.client_max_body_size;
@@ -30,10 +43,10 @@ ContextLocation::ContextLocation(const ContextServer &server) {
     exec_delete          = false;
     cgi_executers        = default_executers;
 }
-ContextLocation::~ContextLocation(void) {}
+ContextLocation::~ContextLocation() {}
 
-ContextLimitExcept::ContextLimitExcept(void) {}
-ContextLimitExcept::~ContextLimitExcept(void) {}
+ContextLimitExcept::ContextLimitExcept() {}
+ContextLimitExcept::~ContextLimitExcept() {}
 
 // 事前に探しておくCGIのエグゼキュータのリスト
 static executer_vector setup_search_executers() {

--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -51,7 +51,11 @@ RequestMatchingResult RequestMatcher::request_match(const std::vector<config::Co
 
 RequestMatchingResult
 RequestMatcher::routing_cgi(RequestMatchingResult res, const RequestTarget &target, const config::Config &conf) {
-    res.cgi_resource      = make_cgi_resource(target, conf);
+    res.cgi_resource = make_cgi_resource(target, conf);
+    if (res.cgi_resource.script_name.empty()) {
+        res.error = minor_error::make("file not found", HTTP::STATUS_NOT_FOUND);
+        return res;
+    }
     res.path_cgi_executor = get_path_cgi_executor(target, conf, res.cgi_resource.script_name);
     res.result_type       = RequestMatchingResult::RT_CGI;
     return res;
@@ -94,9 +98,6 @@ RequestMatchingResult::CGIResource RequestMatcher::make_cgi_resource(const Reque
         }
         i += 1;
     }
-    if (resource.script_name.empty()) {
-        throw http_error("file not found", HTTP::STATUS_NOT_FOUND);
-    }
     return resource;
 }
 
@@ -106,10 +107,12 @@ RequestMatchingResult RequestMatcher::routing_default(RequestMatchingResult res,
                                                       const config::Config &conf) {
     std::pair<HTTP::byte_string, bool> path_isdir = make_resource_path(target, conf);
     if (target.form != RequestTarget::FORM_ORIGIN) {
-        throw http_error("form of a target is not an origin-form", HTTP::STATUS_BAD_REQUEST);
+        res.error = minor_error::make("form of a target is not an origin-form", HTTP::STATUS_BAD_REQUEST);
+        return res;
     }
     if (path_isdir.first.empty()) {
-        throw http_error("file not found", HTTP::STATUS_NOT_FOUND);
+        res.error = minor_error::make("file not found", HTTP::STATUS_NOT_FOUND);
+        return res;
     }
     res.path_local  = path_isdir.first;
     res.result_type = RequestMatchingResult::RT_FILE;
@@ -120,7 +123,8 @@ RequestMatchingResult RequestMatcher::routing_default(RequestMatchingResult res,
             res.result_type = RequestMatchingResult::RT_AUTO_INDEX;
         } else {
             DXOUT("PMDD");
-            throw http_error("permission denied", HTTP::STATUS_FORBIDDEN);
+            res.error = minor_error::make("permission denied", HTTP::STATUS_FORBIDDEN);
+            return res;
         }
     } else if (get_is_executable(target, method, conf)) {
         switch (method) {
@@ -183,7 +187,7 @@ minor_error RequestMatcher::check_routable(const IRequestMatchingParam &rp, cons
     const RequestTarget &target = rp.get_request_target();
 
     if (target.is_error) {
-        throw http_error("target has an error", HTTP::STATUS_BAD_REQUEST);
+        return minor_error::make("target has an error", HTTP::STATUS_BAD_REQUEST);
     }
     if (!is_valid_scheme(target)) {
         return minor_error::make("invalid scheme", HTTP::STATUS_BAD_REQUEST);

--- a/test_case/config/normal_directive.cpp
+++ b/test_case/config/normal_directive.cpp
@@ -39,8 +39,8 @@ TEST_F(normal_directive_test, get_error_page) {
 
     const std::string target = "/";
     std::map<HTTP::t_status, std::string> error_page;
-    //    error_page[404] = "";
-    EXPECT_EQ(error_page, conf.get_error_page(target));
+    config::ContextLocation loc;
+    EXPECT_EQ(loc.error_pages, conf.get_error_page(target));
 }
 
 TEST_F(normal_directive_test, get_index) {
@@ -161,18 +161,27 @@ TEST_F(normal_directive_test, get_error_page_from_mix_context) {
     const config::host_port_pair hp = std::make_pair("127.0.0.1", 80);
     const config::Config conf       = configs[hp].front();
 
-    std::map<HTTP::t_status, std::string> error_page;
-    error_page[HTTP::STATUS_BAD_REQUEST] = "error.html";
-    EXPECT_EQ(error_page, conf.get_error_page("/"));
-    error_page.clear();
-    error_page[HTTP::STATUS_UNAUTHORIZED] = "error1.html";
-    EXPECT_EQ(error_page, conf.get_error_page("/dir1"));
-    error_page.clear();
-    error_page[(HTTP::t_status)402] = "error2.html";
-    EXPECT_EQ(error_page, conf.get_error_page("/dir2"));
-    error_page.clear();
-    error_page[HTTP::STATUS_FORBIDDEN] = "error3.html";
-    EXPECT_EQ(error_page, conf.get_error_page("/dir2/dir3"));
+    {
+        std::map<HTTP::t_status, std::string> error_page;
+        config::ContextLocation loc;
+        loc.error_pages[HTTP::STATUS_BAD_REQUEST] = "error.html";
+        EXPECT_EQ(loc.error_pages, conf.get_error_page("/"));
+    }
+    {
+        config::ContextLocation loc;
+        loc.error_pages[HTTP::STATUS_UNAUTHORIZED] = "error1.html";
+        EXPECT_EQ(loc.error_pages, conf.get_error_page("/dir1"));
+    }
+    {
+        config::ContextLocation loc;
+        loc.error_pages[(HTTP::t_status)402] = "error2.html";
+        EXPECT_EQ(loc.error_pages, conf.get_error_page("/dir2"));
+    }
+    {
+        config::ContextLocation loc;
+        loc.error_pages[HTTP::STATUS_FORBIDDEN] = "error3.html";
+        EXPECT_EQ(loc.error_pages, conf.get_error_page("/dir2/dir3"));
+    }
 }
 
 TEST_F(normal_directive_test, get_index_from_mix_context) {

--- a/test_case/config/original_directive.cpp
+++ b/test_case/config/original_directive.cpp
@@ -10,10 +10,10 @@
 #include <vector>
 
 namespace {
-class config_original : public testing::Test {
+class original_directive_test : public testing::Test {
 protected:
-    config_original() {}
-    virtual ~config_original() {}
+    original_directive_test() {}
+    virtual ~original_directive_test() {}
     void setup_based_on_str(const std::string &data) {
         configs = parser.parse(data);
     }
@@ -22,7 +22,7 @@ protected:
     std::map<config::host_port_pair, std::vector<config::Config> > configs;
 };
 
-TEST_F(config_original, get_exec_cgi) {
+TEST_F(original_directive_test, get_exec_cgi) {
     const std::string config_data = "\
 http { \
     server { \
@@ -45,7 +45,7 @@ http { \
     EXPECT_EQ(false, conf.get_exec_cgi("/off/"));
 }
 
-TEST_F(config_original, get_exec_delete) {
+TEST_F(original_directive_test, get_exec_delete) {
     const std::string config_data = "\
 http { \
     server { \
@@ -67,7 +67,7 @@ http { \
     EXPECT_EQ(false, conf.get_exec_delete("/off/"));
 }
 
-TEST_F(config_original, get_cgi_path) {
+TEST_F(original_directive_test, get_cgi_path) {
     const std::string config_data = "\
 http { \
     server { \
@@ -110,7 +110,7 @@ http { \
     }
 }
 
-TEST_F(config_original, request_match_cgi_found) {
+TEST_F(original_directive_test, request_match_cgi_found) {
     const std::string config_data = "\
 http { \
     server { \
@@ -155,7 +155,7 @@ http { \
     }
 }
 
-TEST_F(config_original, request_match_cgi_not_found) {
+TEST_F(original_directive_test, request_match_cgi_not_found) {
     const std::string config_data = "\
 http { \
     server { \
@@ -179,12 +179,8 @@ http { \
 
     {
         TestParam tp(HTTP::METHOD_GET, "/ruby/not_exist.rb/path/after", HTTP::V_1_1, "localhost", "80");
-        EXPECT_THROW(
-            {
-                RequestMatchingResult res = rm.request_match(configs[hp], tp);
-                EXPECT_TRUE(res.error.is_error());
-            },
-            http_error);
+        RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_TRUE(res.error.is_error());
     }
 }
 

--- a/test_case/config/request_matcher.cpp
+++ b/test_case/config/request_matcher.cpp
@@ -271,25 +271,22 @@ http { \
 
     {
         TestParam tp(HTTP::METHOD_GET, "/tests/%E3%81%B0%E3%81%AA%E3%81%AA.html", HTTP::V_1_1, "localhost", "80");
-        EXPECT_NO_THROW({
-            const RequestMatchingResult res = rm.request_match(configs[hp], tp);
-            EXPECT_EQ(HTTP::strfy("./tests/ばなな.html"), res.path_local);
-        });
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("./tests/ばなな.html"), res.path_local);
     }
 
     {
         // 先頭以外のスラッシュを"%2F"に置換
         TestParam tp(HTTP::METHOD_GET, "/tests%2F%E3%81%B0%E3%81%AA%E3%81%AA.html", HTTP::V_1_1, "localhost", "80");
-        EXPECT_NO_THROW({
-            const RequestMatchingResult res = rm.request_match(configs[hp], tp);
-            EXPECT_EQ(HTTP::strfy("./tests/ばなな.html"), res.path_local);
-        });
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("./tests/ばなな.html"), res.path_local);
     }
 
     {
         // 先頭のスラッシュを"%2F"に置換 → ヒットしなくなる
         TestParam tp(HTTP::METHOD_GET, "%2Ftests%2F%E3%81%B0%E3%81%AA%E3%81%AA.html", HTTP::V_1_1, "localhost", "80");
-        EXPECT_THROW(rm.request_match(configs[hp], tp);, http_error);
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_TRUE(res.error.is_error());
     }
 
     {
@@ -298,10 +295,8 @@ http { \
                      HTTP::V_1_1,
                      "localhost",
                      "80");
-        EXPECT_NO_THROW({
-            const RequestMatchingResult res = rm.request_match(configs[hp], tp);
-            EXPECT_EQ(HTTP::strfy("./tests/ふぉーてぃーつー/banana.txt"), res.path_local);
-        });
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("./tests/ふぉーてぃーつー/banana.txt"), res.path_local);
     }
 }
 


### PR DESCRIPTION
#### 概要

resolve #204 
configでエラーページディレクティブが定義されていても使われていなかった。

#### やったこと
- request_matchで例外を投げずに、minor_errorを返すようにした
- RoundTripのメンバにエラーページを持たせるようにした
- conf側で、defaultのエラーページのパスを定義するようにした
    - 404, 405, 500のみ定義している

#### エラーページの処理例

confにエラーページの定義がない
- デフォルトのエラーページを返す
- 404, 405, 500 以外の場合、`ErrorPageGenerator` が作成したエラーページを返す

confにエラーページの定義があり、ファイルが存在する
`error_page 404 ./404.html;`
- 404エラー発生 -> ./404.html を返す

confにエラーページの定義があり、ファイルが存在しない
`error_page 404 ./not_found.html;`
- 404エラー発生 -> ./not_found.htmlが存在しない -> `ErrorPageGenerator` が作成したエラーページを返す


