### PR TITLE
POSTリクエストに対するステータスコードを設定

### DIFF
--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -34,7 +34,10 @@ FilePoster::FileEntry::FileEntry(const byte_string &name_,
     : name(name_), content(content_), content_type(content_type_), content_disposition(content_disposition_) {}
 
 FilePoster::FilePoster(const RequestMatchingResult &match_result, const IContentProvider &request)
-    : directory_path_(HTTP::restrfy(match_result.path_local)), originated_(false), content_provider(request) {
+    : directory_path_(HTTP::restrfy(match_result.path_local))
+    , request_path(match_result.target->path)
+    , originated_(false)
+    , content_provider(request) {
     // リクエストの Content-Type: が "multipart/form-data" でかつ正しい boundary パラメータがあれば,
     // マルチパートとみなして処理する.
     const HTTP::CH::ContentType &ct = content_provider.get_content_type_item();
@@ -235,9 +238,9 @@ void FilePoster::leave() {
     delete this;
 }
 
-ResponseHTTP *FilePoster::respond(const RequestHTTP *request) {
+ResponseHTTP::header_list_type
+FilePoster::determine_response_headers(const IResponseDataConsumer::t_sending_mode sm) const {
     ResponseHTTP::header_list_type headers;
-    IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
     switch (sm) {
         case ResponseDataList::SM_CHUNKED:
             headers.push_back(std::make_pair(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked")));
@@ -249,7 +252,15 @@ ResponseHTTP *FilePoster::respond(const RequestHTTP *request) {
         default:
             break;
     }
-    ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
+    headers.push_back(std::make_pair(HeaderHTTP::location, request_path.str()));
+    return headers;
+}
+
+ResponseHTTP *FilePoster::respond(const RequestHTTP *request) {
+    const IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
+    ResponseHTTP::header_list_type headers         = determine_response_headers(sm);
+    ResponseHTTP *res
+        = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_CREATED, &headers, &response_data, false);
     res->start();
     return res;
 }

--- a/src/originator/FilePoster.hpp
+++ b/src/originator/FilePoster.hpp
@@ -31,6 +31,7 @@ public:
 
 private:
     char_string directory_path_;
+    light_string request_path;
     ResponseDataList response_data;
     bool originated_;
     const IContentProvider &content_provider;
@@ -50,6 +51,7 @@ private:
     void analyze_subpart(const light_string &subpart);
     // FileEntryの内容をディスクに書き込む
     void write_file(const FileEntry &file) const;
+    ResponseHTTP::header_list_type determine_response_headers(const IResponseDataConsumer::t_sending_mode sm) const;
 
 public:
     FilePoster(const RequestMatchingResult &match_result, const IContentProvider &request);

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -34,6 +34,8 @@ const HTTP::byte_string HTTP::reason(HTTP::t_status status) {
         // 2**
         case HTTP::STATUS_OK:
             return strfy("OK");
+        case STATUS_CREATED:
+            return strfy("Created");
         // 3**
         case HTTP::STATUS_MOVED_PERMANENTLY:
             return strfy("Moved Permanently");

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -16,7 +16,8 @@ enum t_status {
     // 1**
     STATUS_UNSPECIFIED = 1,
     // 2**
-    STATUS_OK = 200,
+    STATUS_OK      = 200,
+    STATUS_CREATED = 201,
     // 3**
     STATUS_MOVED_PERMANENTLY  = 301,
     STATUS_FOUND              = 302,


### PR DESCRIPTION
`Location:`も返す。
`Location:`はリクエストパスをそのまま返す。

#216 待ち