### PR TITLE
#208 FileDeleterがレスポンスを返すように修正

### DIFF
--- a/src/originator/FileDeleter.cpp
+++ b/src/originator/FileDeleter.cpp
@@ -36,6 +36,8 @@ void FileDeleter::delete_file() {
         }
         return;
     }
+    const byte_string msg = HTTP::strfy("\"" + file_path_ + "\"" + " was successfully deleted.\n");
+    response_data.inject(msg, false);
     response_data.inject("", 0, true);
     originated_ = true;
 }
@@ -75,8 +77,20 @@ void FileDeleter::leave() {
 }
 
 ResponseHTTP *FileDeleter::respond(const RequestHTTP *request) {
-    response_data.determine_sending_mode();
-    ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, NULL, &response_data, false);
+    ResponseHTTP::header_list_type headers;
+    IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
+    switch (sm) {
+        case ResponseDataList::SM_CHUNKED:
+            headers.push_back(std::make_pair(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked")));
+            break;
+        case ResponseDataList::SM_NOT_CHUNKED:
+            headers.push_back(
+                std::make_pair(HeaderHTTP::content_length, ParserHelper::utos(response_data.current_total_size(), 10)));
+            break;
+        default:
+            break;
+    }
+    ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
     res->start();
     return res;
 }


### PR DESCRIPTION
#### 概要
resolve #208 
FIleDeleterがレスポンスを返すように修正した。

ファイル削除が成功したことがわかりやすいようにbodyを返すようにしている。
```
> touch delete/a
> curl -X DELETE localhost:82/delete/a    
"./delete/a" was successfully deleted.
```
