### PR TITLE
リクエストマッチのリファクタ

### DIFF
--- a/src/interface/IRequestMatcher.hpp
+++ b/src/interface/IRequestMatcher.hpp
@@ -18,7 +18,8 @@ struct RequestMatchingResult {
         RT_EXTERNAL_REDIRECTION,
         RT_CGI,
         RT_AUTO_INDEX,
-        RT_ECHO
+        RT_ECHO,
+        RT_ERROR
     };
 
     minor_error error;

--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -67,8 +67,9 @@ RequestMatcher::routing_cgi(RequestMatchingResult res, const RequestTarget &targ
 /**
  * 以下の形式でパスを分割する
  * リクエスト: `/cgi-bin/cgi.rb/pathinfo`
+ * fullpath   : /cgi-bin/cgi.rb (local path)
  * root       : /cgi-bin
- * cgi_script : /cgi.rb
+ * script_name: /cgi-bin/cgi.rb (request path)
  * path_info  : /pathinfo
  */
 RequestMatchingResult::CGIResource RequestMatcher::make_cgi_resource(const RequestTarget &target,
@@ -79,6 +80,7 @@ RequestMatchingResult::CGIResource RequestMatcher::make_cgi_resource(const Reque
     const HTTP::light_string path_stripped    = HTTP::Utils::lstrip_path(target.dpath_slash_reduced());
     const HTTP::byte_string full_request_path = HTTP::Utils::join_path(root_stripped, path_stripped);
     const light_string path                   = full_request_path;
+
     RequestMatchingResult::CGIResource resource;
     resource.root = root_stripped.str();
     for (size_t i = root_stripped.size();; i = path.find("/", i)) {
@@ -90,10 +92,6 @@ RequestMatchingResult::CGIResource RequestMatcher::make_cgi_resource(const Reque
             if (i != HTTP::npos) {
                 resource.path_info = path.substr(i).str();
             }
-            QVOUT(resource.fullpath);
-            QVOUT(resource.root);
-            QVOUT(resource.script_name);
-            QVOUT(resource.path_info);
             break;
         }
         if (i == HTTP::npos) {
@@ -121,6 +119,43 @@ std::pair<HTTP::byte_string, bool> RequestMatcher::make_post_path(const RequestT
     return std::make_pair(HTTP::strfy(""), false);
 }
 
+RequestMatchingResult::ResultType RequestMatcher::get_result_type_from_dir(const RequestTarget &target,
+                                                                           const HTTP::t_method &method,
+                                                                           const config::Config &conf) const {
+    if (is_executable(target, method, conf) && method == HTTP::METHOD_POST) {
+        return RequestMatchingResult::RT_FILE_POST;
+    }
+    if (is_autoindex(target, conf)) {
+        return RequestMatchingResult::RT_AUTO_INDEX;
+    }
+    return RequestMatchingResult::RT_ERROR;
+}
+
+RequestMatchingResult::ResultType RequestMatcher::get_result_type_from_file(const RequestTarget &target,
+                                                                            const HTTP::t_method &method,
+                                                                            const config::Config &conf) const {
+    if (is_executable(target, method, conf)) {
+        switch (method) {
+            case HTTP::METHOD_DELETE:
+                return RequestMatchingResult::RT_FILE_DELETE;
+            case HTTP::METHOD_PUT:
+                return RequestMatchingResult::RT_FILE_PUT;
+            default:;
+        }
+    }
+    return RequestMatchingResult::RT_FILE;
+}
+
+RequestMatchingResult::ResultType RequestMatcher::get_result_type(const RequestTarget &target,
+                                                                  const HTTP::t_method &method,
+                                                                  const config::Config &conf,
+                                                                  const bool &isdir) const {
+    if (isdir) {
+        return get_result_type_from_dir(target, method, conf);
+    }
+    return get_result_type_from_file(target, method, conf);
+}
+
 RequestMatchingResult RequestMatcher::routing_default(RequestMatchingResult res,
                                                       const RequestTarget &target,
                                                       const HTTP::t_method &method,
@@ -140,36 +175,18 @@ RequestMatchingResult RequestMatcher::routing_default(RequestMatchingResult res,
         res.error = minor_error::make("file not found", HTTP::STATUS_NOT_FOUND);
         return res;
     }
-    res.path_local  = path_isdir.first;
-    res.result_type = RequestMatchingResult::RT_FILE;
-    if (path_isdir.second) {
-        if (get_is_executable(target, method, conf) && method == HTTP::METHOD_POST) {
-            res.result_type = RequestMatchingResult::RT_FILE_POST;
-        } else if (get_is_autoindex(target, conf)) {
-            res.result_type = RequestMatchingResult::RT_AUTO_INDEX;
-        } else {
-            DXOUT("PMDD");
-            res.error = minor_error::make("permission denied", HTTP::STATUS_FORBIDDEN);
-            return res;
-        }
-    } else if (get_is_executable(target, method, conf)) {
-        switch (method) {
-            case HTTP::METHOD_DELETE:
-                res.result_type = RequestMatchingResult::RT_FILE_DELETE;
-                break;
-            case HTTP::METHOD_PUT:
-                res.result_type = RequestMatchingResult::RT_FILE_PUT;
-                break;
-            default:
-                break;
-        }
+    res.path_local   = path_isdir.first;
+    const bool isdir = path_isdir.second;
+    res.result_type  = get_result_type(target, method, conf, isdir);
+    if (res.result_type == RequestMatchingResult::RT_ERROR) {
+        res.error = minor_error::make("permission denied", HTTP::STATUS_FORBIDDEN);
     }
     return res;
 }
 
-bool RequestMatcher::get_is_executable(const RequestTarget &target,
-                                       const HTTP::t_method &method,
-                                       const config::Config &conf) {
+bool RequestMatcher::is_executable(const RequestTarget &target,
+                                   const HTTP::t_method &method,
+                                   const config::Config &conf) const {
     const std::string &path = HTTP::restrfy(target.dpath_slash_reduced());
 
     switch (method) {
@@ -184,7 +201,7 @@ bool RequestMatcher::get_is_executable(const RequestTarget &target,
     return false;
 }
 
-bool RequestMatcher::get_is_autoindex(const RequestTarget &target, const config::Config &conf) {
+bool RequestMatcher::is_autoindex(const RequestTarget &target, const config::Config &conf) const {
     const std::string &path = HTTP::restrfy(target.dpath_slash_reduced());
     return conf.get_autoindex(path);
 }

--- a/src/router/RequestMatcher.hpp
+++ b/src/router/RequestMatcher.hpp
@@ -35,8 +35,19 @@ private:
     bool is_cgi(const RequestTarget &target, const config::Config &conf);
     bool is_post(const RequestTarget &target, const HTTP::t_method &method, const config::Config &conf);
 
-    bool get_is_executable(const RequestTarget &target, const HTTP::t_method &method, const config::Config &conf);
-    bool get_is_autoindex(const RequestTarget &target, const config::Config &conf);
+    RequestMatchingResult::ResultType get_result_type(const RequestTarget &target,
+                                                      const HTTP::t_method &method,
+                                                      const config::Config &conf,
+                                                      const bool &isdir) const;
+    RequestMatchingResult::ResultType get_result_type_from_dir(const RequestTarget &target,
+                                                               const HTTP::t_method &method,
+                                                               const config::Config &conf) const;
+    RequestMatchingResult::ResultType get_result_type_from_file(const RequestTarget &target,
+                                                                const HTTP::t_method &method,
+                                                                const config::Config &conf) const;
+
+    bool is_executable(const RequestTarget &target, const HTTP::t_method &method, const config::Config &conf) const;
+    bool is_autoindex(const RequestTarget &target, const config::Config &conf) const;
     long get_client_max_body_size(const RequestTarget &target, const config::Config &conf) const;
     redirect_pair get_redirect(const RequestTarget &target, const config::Config &conf) const;
     RequestMatchingResult::status_dict_type get_status_page_dict(const RequestTarget &target,


### PR DESCRIPTION
#### やったこと

- `routing_default`  の処理をディレクトリとファイルの場合で分割した。
- エラー判定にResultTypeが使いたかったので、エラー用の属性を追加している。
- `get_is_autoindex` だとややこしいので、 `is_autoindex` のように名前を変更している。