### PR TITLE
vmでコンパイルを通すために色々修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ TEST_CASE_SRCS			=	$(shell find $(TEST_CASE_SRC_DIR) -type f -name "*.cpp")
 TEST_CASE_OBJS			=	$(addprefix $(TEST_CASE_OBJ_DIR)/,  $(TEST_CASE_SRCS:.cpp=.o))
 TEST_CASE_DPS			=	$(addprefix $(TEST_CASE_DPS_DIR)/,  $(TEST_CASE_SRCS:.cpp=.d))
 
-#CF						=	clang-format
+CF						=	clang-format
 
 .PHONY: all cf
 all: cf $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ TEST_CASE_SRCS			=	$(shell find $(TEST_CASE_SRC_DIR) -type f -name "*.cpp")
 TEST_CASE_OBJS			=	$(addprefix $(TEST_CASE_OBJ_DIR)/,  $(TEST_CASE_SRCS:.cpp=.o))
 TEST_CASE_DPS			=	$(addprefix $(TEST_CASE_DPS_DIR)/,  $(TEST_CASE_SRCS:.cpp=.d))
 
-CF						=	clang-format
+#CF						=	clang-format
 
 .PHONY: all cf
 all: cf $(NAME)

--- a/src/communication/ControlHeaderHTTP.cpp
+++ b/src/communication/ControlHeaderHTTP.cpp
@@ -220,7 +220,7 @@ minor_error HTTP::CH::ContentType::determine(const AHeaderHolder &holder) {
     light_string parameters_str(lct, subtype_end);
     ARoutingParameters::decompose_semicoron_separated_kvlist(parameters_str, *this);
     {
-        HTTP::IDictHolder::parameter_dict::const_iterator it = parameters.find(HTTP::strfy("charset"));
+        HTTP::IDictHolder::parameter_dict::iterator it = parameters.find(HTTP::strfy("charset"));
         if (it != parameters.end()) {
             charset = it->second.str();
             parameters.erase(it);

--- a/src/communication/HeaderHTTP.cpp
+++ b/src/communication/HeaderHTTP.cpp
@@ -3,7 +3,8 @@
     {                                                                                                                  \
         HeaderAttribute attr = {                                                                                       \
             list,                                                                                                      \
-            aggr,                                                                                                      \            uniq,                                                                                                      \
+            aggr,                                                                                                      \
+            uniq,                                                                                                      \
         };                                                                                                             \
         predefined_attrs[key] = attr;                                                                                  \
     }
@@ -20,20 +21,20 @@ void HeaderAttribute::set_predefined_attrs() {
     // https://triple-underscore.github.io/RFC7230-ja.html#_xref-6-10
     // "TE"ヘッダとは別物(TEは同じメッセージへの応答に対する指定; Transfer-Encodingは同じメッセージに対する指定)
     // - list, multiple
-//    DEFINE_ATTR(HeaderHTTP::transfer_encoding, 1, 1, 0);
+    DEFINE_ATTR(HeaderHTTP::transfer_encoding, 1, 1, 0);
     // [te]
     // https://triple-underscore.github.io/RFC7230-ja.html#section-4.3
- //   DEFINE_ATTR(HeaderHTTP::te, 1, 1, 0);
+    DEFINE_ATTR(HeaderHTTP::te, 1, 1, 0);
     // [set-cookie]
     // https://wiki.suikawiki.org/n/Set-Cookie%3A
     // 複数存在可能 & 集約禁止
-//    DEFINE_ATTR(HeaderHTTP::set_cookie, 0, 0, 0);
+    DEFINE_ATTR(HeaderHTTP::set_cookie, 0, 0, 0);
     // [content-length]
     // https://wiki.suikawiki.org/n/Content-Length%3A#anchor-88
-//    DEFINE_ATTR(HeaderHTTP::content_length, 0, 0, 1);
+    DEFINE_ATTR(HeaderHTTP::content_length, 0, 0, 1);
     // [host]
     // https://triple-underscore.github.io/RFC7230-ja.html#header.host
-//    DEFINE_ATTR(HeaderHTTP::host, 0, 0, 1);
+    DEFINE_ATTR(HeaderHTTP::host, 0, 0, 1);
 }
 
 // [HeaderItem]

--- a/src/communication/HeaderHTTP.cpp
+++ b/src/communication/HeaderHTTP.cpp
@@ -3,8 +3,7 @@
     {                                                                                                                  \
         HeaderAttribute attr = {                                                                                       \
             list,                                                                                                      \
-            aggr,                                                                                                      \
-            uniq,                                                                                                      \
+            aggr,                                                                                                      \            uniq,                                                                                                      \
         };                                                                                                             \
         predefined_attrs[key] = attr;                                                                                  \
     }
@@ -21,20 +20,20 @@ void HeaderAttribute::set_predefined_attrs() {
     // https://triple-underscore.github.io/RFC7230-ja.html#_xref-6-10
     // "TE"ヘッダとは別物(TEは同じメッセージへの応答に対する指定; Transfer-Encodingは同じメッセージに対する指定)
     // - list, multiple
-    DEFINE_ATTR(HeaderHTTP::transfer_encoding, 1, 1, 0);
+//    DEFINE_ATTR(HeaderHTTP::transfer_encoding, 1, 1, 0);
     // [te]
     // https://triple-underscore.github.io/RFC7230-ja.html#section-4.3
-    DEFINE_ATTR(HeaderHTTP::te, 1, 1, 0);
+ //   DEFINE_ATTR(HeaderHTTP::te, 1, 1, 0);
     // [set-cookie]
     // https://wiki.suikawiki.org/n/Set-Cookie%3A
     // 複数存在可能 & 集約禁止
-    DEFINE_ATTR(HeaderHTTP::set_cookie, 0, 0, 0);
+//    DEFINE_ATTR(HeaderHTTP::set_cookie, 0, 0, 0);
     // [content-length]
     // https://wiki.suikawiki.org/n/Content-Length%3A#anchor-88
-    DEFINE_ATTR(HeaderHTTP::content_length, 0, 0, 1);
+//    DEFINE_ATTR(HeaderHTTP::content_length, 0, 0, 1);
     // [host]
     // https://triple-underscore.github.io/RFC7230-ja.html#header.host
-    DEFINE_ATTR(HeaderHTTP::host, 0, 0, 1);
+//    DEFINE_ATTR(HeaderHTTP::host, 0, 0, 1);
 }
 
 // [HeaderItem]
@@ -149,7 +148,7 @@ const AHeaderHolder::value_list_type *AHeaderHolder::get_vals(const header_key_t
 
 void AHeaderHolder::erase_vals(const header_key_type &normalized_key) {
     dict.erase(normalized_key);
-    for (list_type::const_iterator it = list.begin(); it != list.end();) {
+    for (list_type::iterator it = list.begin(); it != list.end();) {
         if (it->get_key() == normalized_key) {
             DXOUT("erasing: " << it->get_val());
             list.erase(it++);

--- a/src/communication/RequestTarget.hpp
+++ b/src/communication/RequestTarget.hpp
@@ -39,14 +39,17 @@ struct RequestTarget {
     // 何formか
     t_form form;
 
-    // cf. https://datatracker.ietf.org/doc/html/rfc3986#section-3
-    //
-    //     foo://example.com:8042/over/there?name=ferret#nose
-    //     \_/   \______________/\_________/ \_________/ \__/
-    //     |           |            |            |        |
-    // scheme     authority       path        query   fragment
-    //     |   _____________________|__
-    //     urn:example:animal:ferret:nose
+    /**
+     * cf. https://datatracker.ietf.org/doc/html/rfc3986#section-3
+     *
+     *     foo://example.com:8042/over/there?name=ferret#nose
+     *     \_/   \______________/\_________/ \_________/ \__/
+     *     |           |            |            |        |
+     * scheme     authority       path        query   fragment
+     *     |   _____________________|__
+     *     / \ /                        \
+     *     urn:example:animal:ferret:nose
+     */
 
     light_string scheme;
     light_string authority;

--- a/src/communication/RequestTarget.hpp
+++ b/src/communication/RequestTarget.hpp
@@ -46,7 +46,6 @@ struct RequestTarget {
     //     |           |            |            |        |
     // scheme     authority       path        query   fragment
     //     |   _____________________|__
-    //     / \ /                        \
     //     urn:example:animal:ferret:nose
 
     light_string scheme;

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -584,8 +584,10 @@ void Parser::print_directives(const std::vector<Directive> &d, const bool &is_bl
         if (d[i].block.size() == 0) {
             std::cout << before << dir << "[" << i << "].block  : {}" << std::endl;
         } else {
-            //    std::string b = before + dir + "[" + std::to_string(i) + "]" + ".";
-            //            print_directives(d[i].block, true, b);
+            std::stringstream ss;
+            ss << i;
+            std::string b = before + dir + "[" + ss.str() + "]" + ".";
+            print_directives(d[i].block, true, b);
         }
     }
 }

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -584,8 +584,8 @@ void Parser::print_directives(const std::vector<Directive> &d, const bool &is_bl
         if (d[i].block.size() == 0) {
             std::cout << before << dir << "[" << i << "].block  : {}" << std::endl;
         } else {
-            std::string b = before + dir + "[" + std::to_string(i) + "]" + ".";
-            print_directives(d[i].block, true, b);
+        //    std::string b = before + dir + "[" + std::to_string(i) + "]" + ".";
+//            print_directives(d[i].block, true, b);
         }
     }
 }

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -584,8 +584,8 @@ void Parser::print_directives(const std::vector<Directive> &d, const bool &is_bl
         if (d[i].block.size() == 0) {
             std::cout << before << dir << "[" << i << "].block  : {}" << std::endl;
         } else {
-        //    std::string b = before + dir + "[" + std::to_string(i) + "]" + ".";
-//            print_directives(d[i].block, true, b);
+            //    std::string b = before + dir + "[" + std::to_string(i) + "]" + ".";
+            //            print_directives(d[i].block, true, b);
         }
     }
 }

--- a/src/config/Validator.cpp
+++ b/src/config/Validator.cpp
@@ -3,12 +3,12 @@
 #include "ConfigUtility.hpp"
 #include "Lexer.hpp"
 #include "Parser.hpp"
+#include <cerrno>
 #include <iostream>
 #include <locale>
 #include <map>
 #include <string>
 #include <vector>
-#include <cerrno>
 
 namespace config {
 namespace Validator {

--- a/src/config/Validator.cpp
+++ b/src/config/Validator.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cerrno>
 
 namespace config {
 namespace Validator {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "event/Eventselectloop.hpp"
 #include "server/HTTPServer.hpp"
 #include "utils/MIME.hpp"
+#include <csignal>
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
 
 static void assert_sizeoftype() {
@@ -14,6 +15,7 @@ static void assert_sizeoftype() {
 
 int main(int argc, char **argv) {
     assert_sizeoftype();
+    signal(SIGPIPE, SIG_IGN);
 
     if (argc == 3 && strcmp(argv[1], "-t") == 0) {
         return HTTPServer::test_configuration(argv[2]);

--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -3,9 +3,9 @@
 #include "../utils/File.hpp"
 #include "../utils/HTML.hpp"
 #include <algorithm>
+#include <cerrno>
 #include <ctime>
 #include <sys/stat.h>
-#include <cerrno>
 #include <unistd.h>
 #define READ_SIZE 1024
 
@@ -153,10 +153,10 @@ void AutoIndexer::scan_from_directory() {
             continue;
         }
         entries.resize(entries.size() + 1);
-        entries.back().name    = HTTP::strfy(ent->d_name);
-        entries.back().size    = st.st_size;
-//        entries.back().st_mtim = st.st_mtimespec;
-        entries.back().is_dir  = S_ISDIR(st.st_mode);
+        entries.back().name = HTTP::strfy(ent->d_name);
+        entries.back().size = st.st_size;
+        //        entries.back().st_mtim = st.st_mtimespec;
+        entries.back().is_dir = S_ISDIR(st.st_mode);
     }
     render_html();
     originated_ = true;

--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -150,9 +150,9 @@ void AutoIndexer::scan_from_directory() {
             continue;
         }
         entries.resize(entries.size() + 1);
-        entries.back().name = HTTP::strfy(ent->d_name);
-        entries.back().size = st.st_size;
-        entries.back().time = st.st_mtime;
+        entries.back().name   = HTTP::strfy(ent->d_name);
+        entries.back().size   = st.st_size;
+        entries.back().time   = st.st_mtime;
         entries.back().is_dir = S_ISDIR(st.st_mode);
     }
     render_html();

--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -4,6 +4,8 @@
 #include "../utils/HTML.hpp"
 #include <algorithm>
 #include <ctime>
+#include <sys/stat.h>
+#include <cerrno>
 #include <unistd.h>
 #define READ_SIZE 1024
 
@@ -153,7 +155,7 @@ void AutoIndexer::scan_from_directory() {
         entries.resize(entries.size() + 1);
         entries.back().name    = HTTP::strfy(ent->d_name);
         entries.back().size    = st.st_size;
-        entries.back().st_mtim = st.st_mtimespec;
+//        entries.back().st_mtim = st.st_mtimespec;
         entries.back().is_dir  = S_ISDIR(st.st_mode);
     }
     render_html();

--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -20,10 +20,7 @@ bool compare_entry_by_name(const AutoIndexer::Entry &s1, const AutoIndexer::Entr
 
 // 最終変更時刻 降順
 bool compare_entry_by_mod_time(const AutoIndexer::Entry &s1, const AutoIndexer::Entry &s2) {
-    if (s1.st_mtim.tv_sec == s2.st_mtim.tv_sec) {
-        return s1.st_mtim.tv_nsec > s2.st_mtim.tv_nsec;
-    }
-    return s1.st_mtim.tv_sec > s2.st_mtim.tv_sec;
+    return s1.time > s2.time;
 }
 
 // ディレクトリが先, それ以外が後
@@ -60,12 +57,12 @@ HTTP::byte_string AutoIndexer::Entry::serialize(const HTTP::char_string &request
     // 最終更新時刻
     {
         str += HTTP::strfy("    <td class=\"last-modified\">\n");
-        ss << st_mtim.tv_sec;
+        ss << time;
         ss >> s;
         str += HTTP::strfy("      ");
 
         size_t mlen = 52;
-        tm *tms     = localtime(&st_mtim.tv_sec);
+        tm *tms     = localtime(&time);
         char *tstr  = (char *)malloc(sizeof(char) * (mlen + 1));
         if (tstr != NULL) {
             std::strftime(tstr, mlen, "%d-%m-%Y %H:%M:%S", tms);
@@ -155,7 +152,7 @@ void AutoIndexer::scan_from_directory() {
         entries.resize(entries.size() + 1);
         entries.back().name = HTTP::strfy(ent->d_name);
         entries.back().size = st.st_size;
-        //        entries.back().st_mtim = st.st_mtimespec;
+        entries.back().time = st.st_mtime;
         entries.back().is_dir = S_ISDIR(st.st_mode);
     }
     render_html();

--- a/src/originator/AutoIndexer.hpp
+++ b/src/originator/AutoIndexer.hpp
@@ -19,7 +19,7 @@ public:
     struct Entry {
         HTTP::byte_string name;
         off_t size;
-        struct timespec st_mtim;
+        time_t time;
         bool is_dir;
 
         // 1つのテーブル行としてHTMLに起こす

--- a/src/originator/CGI.cpp
+++ b/src/originator/CGI.cpp
@@ -4,6 +4,8 @@
 #include <cstring>
 #include <signal.h>
 #include <sys/stat.h>
+#include <cerrno>
+#include <sys/wait.h>
 #include <unistd.h>
 #define MAX_SEND_SIZE 1024
 #define MAX_RECEIVE_SIZE 1024

--- a/src/originator/CGI.cpp
+++ b/src/originator/CGI.cpp
@@ -1,10 +1,10 @@
 #include "CGI.hpp"
 #include "../communication/RoundTrip.hpp"
 #include "../utils/File.hpp"
+#include <cerrno>
 #include <cstring>
 #include <signal.h>
 #include <sys/stat.h>
-#include <cerrno>
 #include <sys/wait.h>
 #include <unistd.h>
 #define MAX_SEND_SIZE 1024

--- a/src/originator/FileDeleter.cpp
+++ b/src/originator/FileDeleter.cpp
@@ -1,6 +1,6 @@
 #include "FileDeleter.hpp"
-#include <unistd.h>
 #include <cerrno>
+#include <unistd.h>
 #define WRITE_SIZE 1024
 #define NON_FD -1
 

--- a/src/originator/FileDeleter.cpp
+++ b/src/originator/FileDeleter.cpp
@@ -1,5 +1,6 @@
 #include "FileDeleter.hpp"
 #include <unistd.h>
+#include <cerrno>
 #define WRITE_SIZE 1024
 #define NON_FD -1
 

--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -1,8 +1,8 @@
 #include "FilePoster.hpp"
 #include "../event/time.hpp"
 #include "../utils/File.hpp"
-#include <sys/stat.h>
 #include <cerrno>
+#include <sys/stat.h>
 #include <unistd.h>
 #define WRITE_SIZE 1024
 #define NON_FD -1

--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -2,6 +2,7 @@
 #include "../event/time.hpp"
 #include "../utils/File.hpp"
 #include <sys/stat.h>
+#include <cerrno>
 #include <unistd.h>
 #define WRITE_SIZE 1024
 #define NON_FD -1

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -1,6 +1,7 @@
 #include "FileReader.hpp"
 #include "../utils/MIME.hpp"
 #include <unistd.h>
+#include <cerrno>
 #define READ_SIZE 1048576
 
 FileReader::FileReader(const RequestMatchingResult &match_result, FileCacher &cacher)

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -1,7 +1,7 @@
 #include "FileReader.hpp"
 #include "../utils/MIME.hpp"
-#include <unistd.h>
 #include <cerrno>
+#include <unistd.h>
 #define READ_SIZE 1048576
 
 FileReader::FileReader(const RequestMatchingResult &match_result, FileCacher &cacher)

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -1,5 +1,6 @@
 #include "FileWriter.hpp"
 #include <unistd.h>
+#include <cerrno>
 #define WRITE_SIZE 1024
 
 FileWriter::FileWriter(const RequestMatchingResult &match_result, const byte_string &content_to_write)

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -1,6 +1,6 @@
 #include "FileWriter.hpp"
-#include <unistd.h>
 #include <cerrno>
+#include <unistd.h>
 #define WRITE_SIZE 1024
 
 FileWriter::FileWriter(const RequestMatchingResult &match_result, const byte_string &content_to_write)

--- a/src/socket/ASocket.cpp
+++ b/src/socket/ASocket.cpp
@@ -16,15 +16,15 @@ ASocket::ASocket(t_socket_domain sdomain, t_socket_type stype) : port(0) {
     yes = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
     yes = 1;
-    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
+//    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(t_fd sock_fd, t_socket_domain sdomain, t_socket_type stype) : fd(sock_fd), port(0) {
     domain = sdomain;
     type   = stype;
-    int yes;
-    yes = 1;
-    setsockopt(sock_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
+//    int yes;
+ //   yes = 1;
+//    setsockopt(sock_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(const ASocket &other) {

--- a/src/socket/ASocket.cpp
+++ b/src/socket/ASocket.cpp
@@ -15,16 +15,11 @@ ASocket::ASocket(t_socket_domain sdomain, t_socket_type stype) : port(0) {
     int yes;
     yes = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
-    yes = 1;
-    //    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(t_fd sock_fd, t_socket_domain sdomain, t_socket_type stype) : fd(sock_fd), port(0) {
     domain = sdomain;
     type   = stype;
-    //    int yes;
-    //   yes = 1;
-    //    setsockopt(sock_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(const ASocket &other) {

--- a/src/socket/ASocket.cpp
+++ b/src/socket/ASocket.cpp
@@ -16,15 +16,15 @@ ASocket::ASocket(t_socket_domain sdomain, t_socket_type stype) : port(0) {
     yes = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
     yes = 1;
-//    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
+    //    setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(t_fd sock_fd, t_socket_domain sdomain, t_socket_type stype) : fd(sock_fd), port(0) {
     domain = sdomain;
     type   = stype;
-//    int yes;
- //   yes = 1;
-//    setsockopt(sock_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
+    //    int yes;
+    //   yes = 1;
+    //    setsockopt(sock_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));
 }
 
 ASocket::ASocket(const ASocket &other) {

--- a/src/socket/SocketListening.cpp
+++ b/src/socket/SocketListening.cpp
@@ -1,5 +1,6 @@
 #include "SocketListening.hpp"
 #include "../utils//test_common.hpp"
+#include <cerrno>
 #include "SocketConnected.hpp"
 #include "strings.h"
 

--- a/src/socket/SocketListening.cpp
+++ b/src/socket/SocketListening.cpp
@@ -1,8 +1,8 @@
 #include "SocketListening.hpp"
 #include "../utils//test_common.hpp"
-#include <cerrno>
 #include "SocketConnected.hpp"
 #include "strings.h"
+#include <cerrno>
 
 SocketListening::SocketListening(t_socket_domain sdomain, t_socket_type stype) : ASocket(sdomain, stype) {}
 

--- a/src/utils/File.cpp
+++ b/src/utils/File.cpp
@@ -54,8 +54,8 @@ std::string get_directory_name(const std::string &file_path) {
 }
 
 std::string read(const std::string &path) {
-    std::ifstream input_file(path);
-    std::string data((std::istreambuf_iterator<char>(input_file)), std::istreambuf_iterator<char>());
+    std::ifstream input_file(path.c_str());
+  std::string data((std::istreambuf_iterator<char>(input_file)), std::istreambuf_iterator<char>());
     return data;
 }
 

--- a/src/utils/File.cpp
+++ b/src/utils/File.cpp
@@ -55,7 +55,7 @@ std::string get_directory_name(const std::string &file_path) {
 
 std::string read(const std::string &path) {
     std::ifstream input_file(path.c_str());
-  std::string data((std::istreambuf_iterator<char>(input_file)), std::istreambuf_iterator<char>());
+    std::string data((std::istreambuf_iterator<char>(input_file)), std::istreambuf_iterator<char>());
     return data;
 }
 

--- a/src/utils/HTTPError.cpp
+++ b/src/utils/HTTPError.cpp
@@ -17,9 +17,7 @@ minor_error::minor_error() : std::pair<first_type, second_type>("", HTTP::STATUS
 minor_error::minor_error(first_type message, second_type status_code)
     : std::pair<first_type, second_type>(message, status_code) {}
 
-minor_error::minor_error(const minor_error &other) {
-    *this = other;
-}
+minor_error::minor_error(const minor_error &other) : std::pair<first_type, second_type>(other.first, other.second) {}
 
 minor_error::minor_error(const http_error &other) {
     first  = other.what();

--- a/src/utils/LRUCache.hpp
+++ b/src/utils/LRUCache.hpp
@@ -15,7 +15,7 @@ public:
     typedef std::pair<key_type, data_type> value_type;
     typedef std::map<key_type, data_type> data_map_type;
     typedef typename data_map_type::const_iterator const_iterator;
-    typedef std::map<key_type, typename list_type::const_iterator> iterator_map_type;
+    typedef std::map<key_type, typename list_type::iterator> iterator_map_type;
 
 private:
     // キャッシュができる上限値
@@ -51,7 +51,7 @@ public:
         }
 
         // 存在する場合
-        typename list_type::const_iterator it = iter_map_[key];
+        typename list_type::iterator it = iter_map_[key];
         const key_type k                      = *it;
 
         // アクセスリストから削除

--- a/src/utils/LRUCache.hpp
+++ b/src/utils/LRUCache.hpp
@@ -52,7 +52,7 @@ public:
 
         // 存在する場合
         typename list_type::iterator it = iter_map_[key];
-        const key_type k                      = *it;
+        const key_type k                = *it;
 
         // アクセスリストから削除
         access_list_.erase(it);

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -3,7 +3,6 @@
 #include "CharFilter.hpp"
 #include "IndexRange.hpp"
 #include <algorithm>
-#include <string>
 #include <cstring>
 #include <vector>
 

--- a/src/utils/LightString.hpp
+++ b/src/utils/LightString.hpp
@@ -4,6 +4,7 @@
 #include "IndexRange.hpp"
 #include <algorithm>
 #include <string>
+#include <cstring>
 #include <vector>
 
 // 別のstringの一部分をiteratorペアとして参照する軽量string

--- a/src/utils/ObjectHolder.hpp
+++ b/src/utils/ObjectHolder.hpp
@@ -1,6 +1,7 @@
 #ifndef OBJECT_HOLDER_HPP
 #define OBJECT_HOLDER_HPP
 #include "../socket/SocketType.hpp"
+#include <cassert>
 
 // [RAIIクラス(*Holder)について]
 // なんらかのリソースを「所有」した状態で構築される.

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -2,9 +2,9 @@
 #define HTTP_HPP
 #include "test_common.hpp"
 #include "types.hpp"
+#include <cassert>
 #include <iostream>
 #include <map>
-#include <cassert>
 #include <string>
 #include <vector>
 #define MAX_REQLINE_END 8192

--- a/src/utils/http.hpp
+++ b/src/utils/http.hpp
@@ -4,6 +4,7 @@
 #include "types.hpp"
 #include <iostream>
 #include <map>
+#include <cassert>
 #include <string>
 #include <vector>
 #define MAX_REQLINE_END 8192


### PR DESCRIPTION
#### 概要
resolve #235 
42vmでコンパイルエラーが出たところを修正した。

#### やったこと
- includeが抜けてるものを追加
- Parserのデバッグで std::to_stringを使っていたので、C++98で使えるやつに修正
- listのconst_iteratorに対するeraseは、C++11からなので通常のiteratorに修正
- st_mtimespecが使えないので、st_mtimeに変更(ナノ秒レベルでの比較は行わないようにしている)
- `setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&yes, sizeof(yes));` でSO_NOSIGPIPEが使えないので、signal関数でSIGPIPEをignoreするように修正
- ifstreamにstringのconst参照を与えるのがC++98ではできないので、const char*を与えるように修正
- minor_errorのコピーコンストラクタの呼び出し方を修正
- コメント行にバックスラッシュを使うことで、変にエスケープされている箇所を修正

#### その他
- google testがvmだと走らないが、こちらはひとまずそのままで
- clang-formatは提出するタイミングでとるのでつけてます(動作確認時にはコメントアウトしました)
