### PR TITLE
オブジェクト生成処理を例外安全にする

### DIFF
--- a/src/communication/Channel.cpp
+++ b/src/communication/Channel.cpp
@@ -39,9 +39,10 @@ void Channel::notify(IObserver &observer, IObserver::observation_category cat, t
                 // acceptするものが残っていない場合 NULL が返ってくる
                 break;
             }
-            ObjectHolder<Connection> con_holder = new Connection(router_, connected, configs_, cacher_);
-            Connection *con                     = con_holder.value();
-            observer.reserve_hold(con_holder.release());
+            ObjectHolder<Connection> con_holder(new Connection(router_, connected, configs_, cacher_));
+            Connection *con = con_holder.value();
+            observer.reserve_hold(con);
+            con_holder.release();
             observer.reserve_set(con, IObserver::OT_READ);
         }
     } catch (...) {

--- a/src/communication/Channel.cpp
+++ b/src/communication/Channel.cpp
@@ -1,4 +1,5 @@
 #include "Channel.hpp"
+#include "../utils/ObjectHolder.hpp"
 #include "Connection.hpp"
 
 Channel::Channel(IRouter *router,
@@ -38,8 +39,9 @@ void Channel::notify(IObserver &observer, IObserver::observation_category cat, t
                 // acceptするものが残っていない場合 NULL が返ってくる
                 break;
             }
-            Connection *con = new Connection(router_, connected, configs_, cacher_);
-            observer.reserve_hold(con);
+            ObjectHolder<Connection> con_holder = new Connection(router_, connected, configs_, cacher_);
+            Connection *con                     = con_holder.value();
+            observer.reserve_hold(con_holder.release());
             observer.reserve_set(con, IObserver::OT_READ);
         }
     } catch (...) {

--- a/src/communication/ResponseHTTP.cpp
+++ b/src/communication/ResponseHTTP.cpp
@@ -9,7 +9,6 @@ ResponseHTTP::ResponseHTTP(HTTP::t_version version,
     : version_(version)
     , status_(status)
     , lifetime(Lifetime::make_response())
-    , sent_size(0)
     , data_consumer_(data_consumer)
     , should_close_(should_close) {
     if (headers != NULL) {

--- a/src/communication/ResponseHTTP.cpp
+++ b/src/communication/ResponseHTTP.cpp
@@ -19,32 +19,7 @@ ResponseHTTP::ResponseHTTP(HTTP::t_version version,
         }
     }
     lifetime.activate();
-}
-
-ResponseHTTP::ResponseHTTP(HTTP::t_version version, const http_error &error, bool should_close)
-    : version_(version)
-    , status_(error.get_status())
-    , merror(minor_error(error.what(), error.get_status()))
-    , lifetime(Lifetime::make_response())
-    , sent_size(0)
-    , data_consumer_(NULL)
-    , should_close_(should_close) {
-    lifetime.activate();
-    local_datalist.inject("", 0, true);
-    local_datalist.determine_sending_mode();
-}
-
-ResponseHTTP::ResponseHTTP(HTTP::t_version version, const minor_error &error, bool should_close)
-    : version_(version)
-    , status_(error.status_code())
-    , merror(error)
-    , lifetime(Lifetime::make_response())
-    , sent_size(0)
-    , data_consumer_(NULL)
-    , should_close_(should_close) {
-    lifetime.activate();
-    local_datalist.inject("", 0, true);
-    local_datalist.determine_sending_mode();
+    start();
 }
 
 ResponseHTTP::~ResponseHTTP() {}
@@ -115,19 +90,6 @@ bool ResponseHTTP::is_complete() const {
     // VOUT(this);
     // VOUT(consumer());
     return consumer() != NULL && consumer()->is_sending_over();
-}
-
-void ResponseHTTP::swap(ResponseHTTP &lhs, ResponseHTTP &rhs) {
-    std::swap(lhs.version_, rhs.version_);
-    std::swap(lhs.status_, rhs.status_);
-    std::swap(lhs.merror, rhs.merror);
-    std::swap(lhs.sent_size, rhs.sent_size);
-    std::swap(lhs.header_list, rhs.header_list);
-    std::swap(lhs.header_dict, rhs.header_dict);
-    std::swap(lhs.body, rhs.body);
-    std::swap(lhs.message_text, rhs.message_text);
-    std::swap(lhs.local_datalist, rhs.local_datalist);
-    std::swap(lhs.data_consumer_, rhs.data_consumer_);
 }
 
 bool ResponseHTTP::is_error() const {

--- a/src/communication/ResponseHTTP.hpp
+++ b/src/communication/ResponseHTTP.hpp
@@ -44,10 +44,6 @@ public:
                  const header_list_type *headers,
                  IResponseDataConsumer *data_consumer,
                  bool should_close);
-    // unrecovarable エラー応答を構築する
-    ResponseHTTP(HTTP::t_version version, const http_error &error, bool should_close);
-    // recovarable エラー応答を構築する
-    ResponseHTTP(HTTP::t_version version, const minor_error &error, bool should_close);
 
     ~ResponseHTTP();
 
@@ -80,8 +76,6 @@ public:
     bool is_timeout(t_time_epoch_ms now) const;
     // predicate: このレスポンスを送り終わった後, HTTP接続を閉じるべきかどうか
     bool should_close() const;
-
-    static void swap(ResponseHTTP &lhs, ResponseHTTP &rhs);
 };
 
 #endif

--- a/src/communication/ResponseHTTP.hpp
+++ b/src/communication/ResponseHTTP.hpp
@@ -25,7 +25,6 @@ private:
     minor_error merror;
     Lifetime lifetime;
     // 送信済みマーカー
-    size_t sent_size;
     header_list_type header_list;
     header_dict_type header_dict;
     byte_string body;

--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -277,6 +277,5 @@ ResponseHTTP *AutoIndexer::respond(const RequestHTTP *request) {
     const IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
     ResponseHTTP::header_list_type headers         = determine_response_headers(sm);
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/CGI.cpp
+++ b/src/originator/CGI.cpp
@@ -780,11 +780,7 @@ ResponseHTTP *CGI::respond(const RequestHTTP *request) {
     from_script_header_holder.erase_vals(HeaderHTTP::content_type);
     IResponseDataConsumer::t_sending_mode sm = status.response_data.determine_sending_mode();
     ResponseHTTP::header_list_type headers   = determine_response_headers(sm);
-    ResponseHTTP res(request->get_http_version(), response_status, &headers, &status.response_data, false);
-
-    // 例外安全のための copy and swap
-    ResponseHTTP *r = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, NULL, NULL, false);
-    ResponseHTTP::swap(res, *r);
-    r->start();
-    return r;
+    ResponseHTTP *res
+        = new ResponseHTTP(request->get_http_version(), response_status, &headers, &status.response_data, false);
+    return res;
 }

--- a/src/originator/Echoer.cpp
+++ b/src/originator/Echoer.cpp
@@ -62,6 +62,5 @@ ResponseHTTP *Echoer::respond(const RequestHTTP *request) {
             break;
     }
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/ErrorPageGenerator.cpp
+++ b/src/originator/ErrorPageGenerator.cpp
@@ -102,6 +102,5 @@ ResponseHTTP *ErrorPageGenerator::respond(const RequestHTTP *request) {
     ResponseHTTP::header_list_type headers   = determine_response_headers(sm);
     const HTTP::t_version response_http_v    = request ? request->get_http_version() : HTTP::DEFAULT_HTTP_VERSION;
     ResponseHTTP *res = new ResponseHTTP(response_http_v, error.status_code(), &headers, &response_data, should_close_);
-    res->start();
     return res;
 }

--- a/src/originator/FileDeleter.cpp
+++ b/src/originator/FileDeleter.cpp
@@ -91,6 +91,5 @@ ResponseHTTP *FileDeleter::respond(const RequestHTTP *request) {
             break;
     }
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -170,8 +170,8 @@ void FilePoster::analyze_subpart(const light_string &subpart) {
 }
 
 void FilePoster::write_file(const FileEntry &file) const {
-    FDHolder fd_holder = open(HTTP::restrfy(file.name).c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0444);
-    t_fd fd            = fd_holder.value();
+    FDHolder fd_holder(open(HTTP::restrfy(file.name).c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0444));
+    t_fd fd = fd_holder.value();
     // 0444 なのはアップロードされたファイルを即時実行させないため
     if (fd < 0) {
         switch (errno) {

--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -250,6 +250,5 @@ ResponseHTTP *FilePoster::respond(const RequestHTTP *request) {
             break;
     }
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -1,5 +1,6 @@
 #include "FileReader.hpp"
 #include "../utils/MIME.hpp"
+#include "../utils/ObjectHolder.hpp"
 #include <unistd.h>
 #define READ_SIZE 1048576
 
@@ -42,7 +43,8 @@ minor_error FileReader::read_from_file() {
     errno = 0;
     // ファイルを読み込み用に開く
     // 開けなかったらエラー
-    int fd = open(file_path_.c_str(), O_RDONLY | O_CLOEXEC);
+    FDHolder fd_holder = open(file_path_.c_str(), O_RDONLY | O_CLOEXEC);
+    t_fd fd            = fd_holder.value();
     if (fd < 0) {
         switch (errno) {
             case ENOENT:
@@ -62,7 +64,6 @@ minor_error FileReader::read_from_file() {
     for (;;) {
         read_size = read(fd, &read_buf.front(), read_buf.size());
         if (read_size < 0) {
-            close(fd);
             return minor_error::make("read error", HTTP::STATUS_FORBIDDEN);
         }
         read_buf.resize(read_size);
@@ -71,7 +72,6 @@ minor_error FileReader::read_from_file() {
             break;
         }
     }
-    close(fd);
     return minor_error::ok();
 }
 

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -43,8 +43,8 @@ minor_error FileReader::read_from_file() {
     errno = 0;
     // ファイルを読み込み用に開く
     // 開けなかったらエラー
-    FDHolder fd_holder = open(file_path_.c_str(), O_RDONLY | O_CLOEXEC);
-    t_fd fd            = fd_holder.value();
+    FDHolder fd_holder(open(file_path_.c_str(), O_RDONLY | O_CLOEXEC));
+    t_fd fd = fd_holder.value();
     if (fd < 0) {
         switch (errno) {
             case ENOENT:

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -180,6 +180,5 @@ ResponseHTTP *FileReader::respond(const RequestHTTP *request) {
     const IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
     ResponseHTTP::header_list_type headers         = determine_response_headers(sm);
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -92,6 +92,5 @@ void FileWriter::leave() {
 ResponseHTTP *FileWriter::respond(const RequestHTTP *request) {
     response_data.determine_sending_mode();
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, NULL, &response_data, false);
-    res->start();
     return res;
 }

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -21,8 +21,8 @@ void FileWriter::write_to_file() {
     }
     // ファイルを上書きモードで開く.
     // 開けなかったらエラー.
-    FDHolder fd_holder = open(file_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
-    t_fd fd            = fd_holder.value();
+    FDHolder fd_holder(open(file_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644));
+    t_fd fd = fd_holder.value();
     if (fd < 0) {
         switch (errno) {
             case EACCES:

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -1,4 +1,5 @@
 #include "FileWriter.hpp"
+#include "../utils/ObjectHolder.hpp"
 #include <unistd.h>
 #define WRITE_SIZE 1024
 
@@ -20,7 +21,8 @@ void FileWriter::write_to_file() {
     }
     // ファイルを上書きモードで開く.
     // 開けなかったらエラー.
-    int fd = open(file_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    FDHolder fd_holder = open(file_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    t_fd fd            = fd_holder.value();
     if (fd < 0) {
         switch (errno) {
             case EACCES:
@@ -39,7 +41,6 @@ void FileWriter::write_to_file() {
 
         written_size = write(fd, &content_to_write_[write_head], write_max);
         if (written_size < 0) {
-            close(fd);
             throw http_error("write error", HTTP::STATUS_FORBIDDEN);
         }
         write_head += written_size;
@@ -52,7 +53,6 @@ void FileWriter::write_to_file() {
     HTTP::byte_string written_size_str = ParserHelper::utos(write_head, 10);
     response_data.inject(written_size_str, true);
     originated_ = true;
-    close(fd);
 }
 
 void FileWriter::inject_socketlike(ISocketLike *socket_like) {

--- a/src/originator/Redirector.cpp
+++ b/src/originator/Redirector.cpp
@@ -121,7 +121,5 @@ ResponseHTTP *Redirector::respond(const RequestHTTP *request) {
     }
 
     ResponseHTTP *res = new ResponseHTTP(request->get_http_version(), status_code, &headers, &response_data, false);
-
-    res->start();
     return res;
 }

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -53,7 +53,8 @@ void HTTPServer::listen(t_socket_domain sdomain,
     ObjectHolder<Channel> ch_holder(new Channel(this, sdomain, stype, port, configs, cacher));
     Channel *ch            = ch_holder.value();
     channels[ch->get_id()] = ch;
-    socket_observer_->reserve_hold(ch_holder.release());
+    socket_observer_->reserve_hold(ch);
+    ch_holder.release();
     socket_observer_->reserve_set(ch, IObserver::OT_READ);
 }
 

--- a/src/server/HTTPServer.cpp
+++ b/src/server/HTTPServer.cpp
@@ -2,6 +2,7 @@
 #include "../config/Parser.hpp"
 #include "../router/RequestMatcher.hpp"
 #include "../utils/File.hpp"
+#include "../utils/ObjectHolder.hpp"
 
 HTTPServer::HTTPServer(IObserver *observer) : socket_observer_(observer) {}
 
@@ -49,9 +50,10 @@ void HTTPServer::listen(t_socket_domain sdomain,
                         t_port port,
                         const config::config_vector &configs,
                         FileCacher &cacher) {
-    Channel *ch            = new Channel(this, sdomain, stype, port, configs, cacher);
+    ObjectHolder<Channel> ch_holder(new Channel(this, sdomain, stype, port, configs, cacher));
+    Channel *ch            = ch_holder.value();
     channels[ch->get_id()] = ch;
-    socket_observer_->reserve_hold(ch);
+    socket_observer_->reserve_hold(ch_holder.release());
     socket_observer_->reserve_set(ch, IObserver::OT_READ);
 }
 

--- a/src/socket/SocketConnected.cpp
+++ b/src/socket/SocketConnected.cpp
@@ -1,4 +1,5 @@
 #include "SocketConnected.hpp"
+#include "../utils/ObjectHolder.hpp"
 #include "SocketListening.hpp"
 #include <cstring>
 
@@ -15,7 +16,8 @@ SocketConnected &SocketConnected::operator=(const SocketConnected &rhs) {
 }
 
 SocketConnected *SocketConnected::connect(t_socket_domain sdomain, t_socket_type stype, t_port port) {
-    SocketConnected *sock = new SocketConnected(sdomain, stype);
+    ObjectHolder<SocketConnected> sock_holder(new SocketConnected(sdomain, stype));
+    SocketConnected *sock = sock_holder.value();
     t_fd fd               = sock->fd;
 
     sockaddr_in sa;
@@ -35,13 +37,14 @@ SocketConnected *SocketConnected::connect(t_socket_domain sdomain, t_socket_type
         throw std::runtime_error("failed to connect");
     }
     sock->port = port;
-    return sock;
+    return sock_holder.release();
 }
 
 SocketConnected *SocketConnected::wrap(t_fd fd, SocketListening &listening) {
-    SocketConnected *sock = new SocketConnected(fd, listening);
+    ObjectHolder<SocketConnected> sock_holder = new SocketConnected(fd, listening);
+    SocketConnected *sock                     = sock_holder.value();
     sock->set_nonblock();
-    return sock;
+    return sock_holder.release();
 }
 
 ssize_t SocketConnected::send(const void *buffer, size_t len, int flags) {

--- a/src/socket/SocketConnected.cpp
+++ b/src/socket/SocketConnected.cpp
@@ -41,8 +41,8 @@ SocketConnected *SocketConnected::connect(t_socket_domain sdomain, t_socket_type
 }
 
 SocketConnected *SocketConnected::wrap(t_fd fd, SocketListening &listening) {
-    ObjectHolder<SocketConnected> sock_holder = new SocketConnected(fd, listening);
-    SocketConnected *sock                     = sock_holder.value();
+    ObjectHolder<SocketConnected> sock_holder(new SocketConnected(fd, listening));
+    SocketConnected *sock = sock_holder.value();
     sock->set_nonblock();
     return sock_holder.release();
 }

--- a/src/socket/SocketListening.cpp
+++ b/src/socket/SocketListening.cpp
@@ -1,4 +1,5 @@
 #include "SocketListening.hpp"
+#include "../utils//ObjectHolder.hpp"
 #include "../utils//test_common.hpp"
 #include "SocketConnected.hpp"
 #include "strings.h"
@@ -11,7 +12,8 @@ SocketListening &SocketListening::operator=(const SocketListening &rhs) {
 }
 
 SocketListening *SocketListening::bind(t_socket_domain sdomain, t_socket_type stype, t_port port) {
-    SocketListening *sock = new SocketListening(sdomain, stype);
+    ObjectHolder<SocketListening> sock_holder(new SocketListening(sdomain, stype));
+    SocketListening *sock = sock_holder.value();
     sock->set_nonblock();
     t_fd fd = sock->fd;
 
@@ -28,7 +30,7 @@ SocketListening *SocketListening::bind(t_socket_domain sdomain, t_socket_type st
     }
     DXOUT("bound asocket.");
     sock->port = port;
-    return sock;
+    return sock_holder.release();
 }
 
 void SocketListening::listen(int backlog) {

--- a/src/utils/ObjectHolder.hpp
+++ b/src/utils/ObjectHolder.hpp
@@ -2,7 +2,19 @@
 #define OBJECT_HOLDER_HPP
 #include "../socket/SocketType.hpp"
 
-// ファイルディスクリプタRAII用クラス
+// [RAIIクラス(*Holder)について]
+// なんらかのリソースを「所有」した状態で構築される.
+// 「所有」とは, 「所有者が破壊される時, 所有対象もまた破壊される」ことを意味する.
+// *Holder の末路は3つ:
+//
+// 1. リソースを所有したままスコープアウトし, リソースごと破壊される
+// 2. スコープアウトする前にリソースを破壊(destroy)する
+// 3. スコープアウトする前にリソースの所有権を放棄(release)する
+//
+// 正常系では3. 異常系では1. となることが想定される.
+// 2. はちょっと特殊な状況.
+
+// ファイルディスクリプタ用RAIIクラス
 class FDHolder {
 public:
     typedef t_fd value_type;
@@ -10,13 +22,17 @@ public:
 private:
     value_type v_;
 
-    void destroy() throw() {
-        if (v_ >= 0) {
-            close(v_);
-        }
-        waive();
+    FDHolder(const FDHolder &other) {
+        *this = other;
     }
 
+    FDHolder &operator=(const FDHolder &right) {
+        (void)right;
+        assert(false);
+        return *this;
+    }
+
+    // 所有権を手放す
     void waive() throw() {
         v_ = -1;
     }
@@ -38,9 +54,17 @@ public:
         waive();
         return rv;
     }
+
+    // 所有しているオブジェクトを破壊する
+    void destroy() throw() {
+        if (v_ >= 0) {
+            close(v_);
+        }
+        waive();
+    }
 };
 
-// オブジェクトRAII用クラス
+// オブジェクト用RAIIクラス
 template <class U>
 class ObjectHolder {
 public:
@@ -49,11 +73,17 @@ public:
 private:
     value_type v_;
 
-    void destroy() throw() {
-        delete v_;
-        waive();
+    ObjectHolder(const ObjectHolder &other) {
+        *this = other;
     }
 
+    ObjectHolder &operator=(const ObjectHolder &right) {
+        (void)right;
+        assert(false);
+        return *this;
+    }
+
+    // 所有権を手放す
     void waive() throw() {
         v_ = NULL;
     }
@@ -74,6 +104,12 @@ public:
         value_type rv = v_;
         waive();
         return rv;
+    }
+
+    // 所有しているオブジェクトを破壊する
+    void destroy() throw() {
+        delete v_;
+        waive();
     }
 };
 

--- a/src/utils/ObjectHolder.hpp
+++ b/src/utils/ObjectHolder.hpp
@@ -2,6 +2,7 @@
 #define OBJECT_HOLDER_HPP
 #include "../socket/SocketType.hpp"
 
+// ファイルディスクリプタRAII用クラス
 class FDHolder {
 public:
     typedef t_fd value_type;
@@ -9,11 +10,21 @@ public:
 private:
     value_type v_;
 
+    void destroy() throw() {
+        if (v_ >= 0) {
+            close(v_);
+        }
+        waive();
+    }
+
+    void waive() throw() {
+        v_ = -1;
+    }
+
 public:
     FDHolder(value_type v) throw() : v_(v) {}
     ~FDHolder() {
         destroy();
-        waive();
     }
 
     // 保持している値を返す.
@@ -27,19 +38,9 @@ public:
         waive();
         return rv;
     }
-
-    void destroy() throw() {
-        if (v_ >= 0) {
-            close(v_);
-        }
-    }
-
-    void waive() throw() {
-        v_ = -1;
-    }
 };
 
-// new されたオブジェクトの所有権を一時的に保持するためのオブジェクト
+// オブジェクトRAII用クラス
 template <class U>
 class ObjectHolder {
 public:
@@ -48,11 +49,19 @@ public:
 private:
     value_type v_;
 
+    void destroy() throw() {
+        delete v_;
+        waive();
+    }
+
+    void waive() throw() {
+        v_ = NULL;
+    }
+
 public:
     ObjectHolder(value_type v) throw() : v_(v) {}
     ~ObjectHolder() {
         destroy();
-        waive();
     }
 
     // 保持している値を返す.
@@ -65,14 +74,6 @@ public:
         value_type rv = v_;
         waive();
         return rv;
-    }
-
-    void destroy() throw() {
-        delete v_;
-    }
-
-    void waive() throw() {
-        v_ = NULL;
     }
 };
 

--- a/src/utils/ObjectHolder.hpp
+++ b/src/utils/ObjectHolder.hpp
@@ -1,0 +1,79 @@
+#ifndef OBJECT_HOLDER_HPP
+#define OBJECT_HOLDER_HPP
+#include "../socket/SocketType.hpp"
+
+class FDHolder {
+public:
+    typedef t_fd value_type;
+
+private:
+    value_type v_;
+
+public:
+    FDHolder(value_type v) throw() : v_(v) {}
+    ~FDHolder() {
+        destroy();
+        waive();
+    }
+
+    // 保持している値を返す.
+    value_type value() const throw() {
+        return v_;
+    }
+
+    // 保持している値を, 所有権を手放して返す.
+    value_type release() throw() {
+        value_type rv = v_;
+        waive();
+        return rv;
+    }
+
+    void destroy() throw() {
+        if (v_ >= 0) {
+            close(v_);
+        }
+    }
+
+    void waive() throw() {
+        v_ = -1;
+    }
+};
+
+// new されたオブジェクトの所有権を一時的に保持するためのオブジェクト
+template <class U>
+class ObjectHolder {
+public:
+    typedef U *value_type;
+
+private:
+    value_type v_;
+
+public:
+    ObjectHolder(value_type v) throw() : v_(v) {}
+    ~ObjectHolder() {
+        destroy();
+        waive();
+    }
+
+    // 保持している値を返す.
+    value_type value() const throw() {
+        return v_;
+    }
+
+    // 保持している値を, 所有権を手放して返す.
+    value_type release() throw() {
+        value_type rv = v_;
+        waive();
+        return rv;
+    }
+
+    void destroy() throw() {
+        delete v_;
+    }
+
+    void waive() throw() {
+        v_ = NULL;
+    }
+};
+
+#endif


### PR DESCRIPTION
resolve #240

---

`FDHolder`, `ObjectHolder<U>`というRAIIのためのクラスを使って、FDとオブジェクトが宙に浮かないようにしている。