### PR TITLE
`Cookie:`ヘッダにおいて、2つのクッキー間に区切りのSPがなくても許容する

### DIFF
--- a/src/communication/ControlHeaderHTTP.cpp
+++ b/src/communication/ControlHeaderHTTP.cpp
@@ -1009,11 +1009,9 @@ minor_error HTTP::CH::Cookie::determine(const AHeaderHolder &holder) {
                 break;
             }
             work = work.substr(1);
-            if (!work.starts_with(" ")) {
-                merror = minor_error::make("away; no a leading sp for an element", HTTP::STATUS_BAD_REQUEST);
-                break;
+            if (work.starts_with(" ")) {
+                work = work.substr(1);
             }
-            work = work.substr(1);
         }
     }
     return merror;


### PR DESCRIPTION
`siege`が送る`Cookie:`がSPを入れないので・・・
※RFC的には入れるのが正しい: https://www.rfc-editor.org/rfc/rfc6265#section-4.2