### PR TITLE
`Date:`, `Last-Modified:`, `If-Modified-Since:`

### DIFF
--- a/src/communication/ControlHeaderHTTP.cpp
+++ b/src/communication/ControlHeaderHTTP.cpp
@@ -575,6 +575,13 @@ HTTP::byte_string HTTP::CH::Date::serialize() const {
     return ParserHelper::time_to_http_date(value);
 }
 
+// [LastModified]
+HTTP::CH::LastModified::LastModified(t_time_epoch_ms t) : value(t) {}
+
+HTTP::byte_string HTTP::CH::LastModified::serialize() const {
+    return ParserHelper::time_to_http_date(value);
+}
+
 // [Location]
 
 minor_error HTTP::CH::Location::determine(const AHeaderHolder &holder) {

--- a/src/communication/ControlHeaderHTTP.cpp
+++ b/src/communication/ControlHeaderHTTP.cpp
@@ -1,4 +1,5 @@
 #include "ControlHeaderHTTP.hpp"
+#include "../event/time.hpp"
 #include "RoutingParameters.hpp"
 
 typedef HTTP::byte_string byte_string;
@@ -548,7 +549,7 @@ minor_error HTTP::CH::Date::determine(const AHeaderHolder &holder) {
     }
     std::set<t_time_epoch_ms> ts;
     for (AHeaderHolder::value_list_type::const_iterator it = vals->begin(); it != vals->end(); ++it) {
-        std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(*it);
+        std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(*it);
         if (res.first) {
             ts.insert(res.second);
         }
@@ -562,6 +563,16 @@ minor_error HTTP::CH::Date::determine(const AHeaderHolder &holder) {
     VOUT(merror);
     VOUT(value);
     return minor_error::ok();
+}
+
+HTTP::CH::Date HTTP::CH::Date::now() {
+    Date dt;
+    dt.value = WSTime::get_epoch_ms();
+    return dt;
+}
+
+HTTP::byte_string HTTP::CH::Date::serialize() const {
+    return ParserHelper::time_to_http_date(value);
 }
 
 // [Location]
@@ -807,7 +818,7 @@ HTTP::light_string HTTP::CH::CookieEntry::parse_expire(const light_string &str) 
     work                                 = work.substr(1);
     const light_string maybe_date        = work.substr_before(";");
     work                                 = work.substr(maybe_date.size());
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(maybe_date);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(maybe_date);
     if (res.first) {
         expires.set(res.second);
     } else {

--- a/src/communication/ControlHeaderHTTP.cpp
+++ b/src/communication/ControlHeaderHTTP.cpp
@@ -532,8 +532,8 @@ minor_error HTTP::CH::Via::determine(const AHeaderHolder &holder) {
     return minor_error::ok();
 }
 
-// [Date]
-minor_error HTTP::CH::Date::determine(const AHeaderHolder &holder) {
+// [ADate]
+minor_error HTTP::CH::ADate::determine(const AHeaderHolder &holder) {
     // https://www.rfc-editor.org/rfc/rfc9110.html#name-date
     // https://www.rfc-editor.org/rfc/rfc9110.html#name-date-time-formats
     //
@@ -542,7 +542,7 @@ minor_error HTTP::CH::Date::determine(const AHeaderHolder &holder) {
 
     merror                                     = minor_error::ok();
     value                                      = 0;
-    const AHeaderHolder::value_list_type *vals = holder.get_vals(HeaderHTTP::date);
+    const AHeaderHolder::value_list_type *vals = holder.get_vals(get_header_key());
     VOUT(vals);
     if (!vals) {
         return minor_error::ok();
@@ -565,6 +565,11 @@ minor_error HTTP::CH::Date::determine(const AHeaderHolder &holder) {
     return minor_error::ok();
 }
 
+// [Date]
+const HTTP::byte_string &HTTP::CH::Date::get_header_key() const {
+    return HeaderHTTP::date;
+}
+
 HTTP::CH::Date HTTP::CH::Date::now() {
     Date dt;
     dt.value = WSTime::get_epoch_ms();
@@ -573,6 +578,11 @@ HTTP::CH::Date HTTP::CH::Date::now() {
 
 HTTP::byte_string HTTP::CH::Date::serialize() const {
     return ParserHelper::time_to_http_date(value);
+}
+
+// [IfModifiedSince]
+const HTTP::byte_string &HTTP::CH::IfModifiedSince::get_header_key() const {
+    return HeaderHTTP::if_modified_since;
 }
 
 // [LastModified]

--- a/src/communication/ControlHeaderHTTP.hpp
+++ b/src/communication/ControlHeaderHTTP.hpp
@@ -160,6 +160,15 @@ struct Date : public IControlHeader {
     HTTP::byte_string serialize() const;
 };
 
+struct LastModified {
+    t_time_epoch_ms value;
+    minor_error merror;
+
+    LastModified(t_time_epoch_ms t);
+    // 現在保持しているデータを, HTTPヘッダの値として文字列化して返す
+    HTTP::byte_string serialize() const;
+};
+
 struct Location : public IControlHeader {
     HTTP::byte_string value;
     HTTP::light_string abs_path;

--- a/src/communication/ControlHeaderHTTP.hpp
+++ b/src/communication/ControlHeaderHTTP.hpp
@@ -153,6 +153,11 @@ struct Date : public IControlHeader {
     minor_error merror;
 
     minor_error determine(const AHeaderHolder &holder);
+
+    // 現在時刻をあらわす Date オブジェクトを生成
+    static Date now();
+    // 現在保持しているデータを, HTTPヘッダの値として文字列化して返す
+    HTTP::byte_string serialize() const;
 };
 
 struct Location : public IControlHeader {

--- a/src/communication/ControlHeaderHTTP.hpp
+++ b/src/communication/ControlHeaderHTTP.hpp
@@ -148,16 +148,25 @@ struct Via : public IControlHeader {
     minor_error determine(const AHeaderHolder &holder);
 };
 
-struct Date : public IControlHeader {
+struct ADate : public IControlHeader {
     t_time_epoch_ms value;
     minor_error merror;
 
     minor_error determine(const AHeaderHolder &holder);
 
+    virtual const HTTP::byte_string &get_header_key() const = 0;
+};
+
+struct Date : public ADate {
     // 現在時刻をあらわす Date オブジェクトを生成
     static Date now();
     // 現在保持しているデータを, HTTPヘッダの値として文字列化して返す
     HTTP::byte_string serialize() const;
+    const HTTP::byte_string &get_header_key() const;
+};
+
+struct IfModifiedSince : public ADate {
+    const HTTP::byte_string &get_header_key() const;
 };
 
 struct LastModified {

--- a/src/communication/HeaderHTTP.hpp
+++ b/src/communication/HeaderHTTP.hpp
@@ -31,8 +31,8 @@ const HTTP::byte_string date                = ParserHelper::normalize_header_key
 const HTTP::byte_string if_modified_since   = ParserHelper::normalize_header_key(HTTP::strfy("If-Modified-Since"));
 const HTTP::byte_string last_modified       = ParserHelper::normalize_header_key(HTTP::strfy("Last-Modified"));
 // for CGI
-const HTTP::byte_string status   = HTTP::strfy("status");
-const HTTP::byte_string location = HTTP::strfy("location");
+const HTTP::byte_string status   = ParserHelper::normalize_header_key(HTTP::strfy("status"));
+const HTTP::byte_string location = ParserHelper::normalize_header_key(HTTP::strfy("location"));
 
 } // namespace HeaderHTTP
 

--- a/src/communication/HeaderHTTP.hpp
+++ b/src/communication/HeaderHTTP.hpp
@@ -28,6 +28,7 @@ const HTTP::byte_string vary                = ParserHelper::normalize_header_key
 const HTTP::byte_string upgrade             = ParserHelper::normalize_header_key(HTTP::strfy("Upgrade"));
 const HTTP::byte_string via                 = ParserHelper::normalize_header_key(HTTP::strfy("Via"));
 const HTTP::byte_string date                = ParserHelper::normalize_header_key(HTTP::strfy("Date"));
+const HTTP::byte_string last_modified       = ParserHelper::normalize_header_key(HTTP::strfy("Last-Modified"));
 // for CGI
 const HTTP::byte_string status   = HTTP::strfy("status");
 const HTTP::byte_string location = HTTP::strfy("location");

--- a/src/communication/HeaderHTTP.hpp
+++ b/src/communication/HeaderHTTP.hpp
@@ -28,6 +28,7 @@ const HTTP::byte_string vary                = ParserHelper::normalize_header_key
 const HTTP::byte_string upgrade             = ParserHelper::normalize_header_key(HTTP::strfy("Upgrade"));
 const HTTP::byte_string via                 = ParserHelper::normalize_header_key(HTTP::strfy("Via"));
 const HTTP::byte_string date                = ParserHelper::normalize_header_key(HTTP::strfy("Date"));
+const HTTP::byte_string if_modified_since   = ParserHelper::normalize_header_key(HTTP::strfy("If-Modified-Since"));
 const HTTP::byte_string last_modified       = ParserHelper::normalize_header_key(HTTP::strfy("Last-Modified"));
 // for CGI
 const HTTP::byte_string status   = HTTP::strfy("status");

--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -582,8 +582,8 @@ HTTP::byte_string ParserHelper::time_to_http_date(t_time_epoch_ms t) {
     struct tm tm = *gmtime(&now);
     // strftime の結果はロケール依存だが, デフォルトロケールは C 固定のはずなので, 大丈夫なんじゃないの.
     char buf[1000];
-    size_t n = strftime(buf, sizeof buf, "%a, %d %b %Y %H:%M:%S %Z", &tm);
-    return byte_string(buf, buf + n);
+    size_t n = strftime(buf, sizeof buf, "%a, %d %b %Y %H:%M:%S ", &tm);
+    return byte_string(buf, buf + n) + "GMT";
 }
 
 HTTP::byte_string ParserHelper::decode_pct_encoded(const byte_string &str, const HTTP::CharFilter &exclude) {

--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -196,7 +196,24 @@ std::vector<HTTP::light_string> ParserHelper::split(const HTTP::light_string &ls
 }
 
 ParserHelper::byte_string ParserHelper::normalize_header_key(const byte_string &key) {
-    return HTTP::Utils::downcase(key);
+    byte_string normalized = key;
+    light_string lstr(normalized);
+    for (light_string::size_type i = 0; i < normalized.size();) {
+        light_string::size_type r = lstr.find_first_of(HTTP::CharFilter::alpha);
+        if (r == light_string::npos) {
+            break;
+        }
+        i += r;
+        lstr          = lstr.substr(r);
+        normalized[i] = toupper(normalized[i]);
+        i += 1;
+        while (i < normalized.size() && HTTP::CharFilter::alpha.includes(normalized[i])) {
+            normalized[i] = tolower(normalized[i]);
+            i += 1;
+        }
+        lstr = light_string(normalized, i);
+    }
+    return normalized;
 }
 
 ParserHelper::byte_string ParserHelper::normalize_header_key(const HTTP::light_string &key) {

--- a/src/communication/ParserHelper.cpp
+++ b/src/communication/ParserHelper.cpp
@@ -388,7 +388,7 @@ int find_index(const HTTP::light_string &str, const char **list) {
     return -1;
 }
 
-std::pair<bool, t_time_epoch_ms> ParserHelper::str_to_http_date(const light_string &str) {
+std::pair<bool, t_time_epoch_ms> ParserHelper::http_date_to_time(const light_string &str) {
     //   HTTP-date    = IMF-fixdate / obs-date
     //   obs-date     = rfc850-date / asctime-date
     //
@@ -575,6 +575,15 @@ std::pair<bool, t_time_epoch_ms> ParserHelper::str_to_http_date(const light_stri
         }
     } while (0);
     return std::make_pair(false, 0);
+}
+
+HTTP::byte_string ParserHelper::time_to_http_date(t_time_epoch_ms t) {
+    time_t now   = t / 1000;
+    struct tm tm = *gmtime(&now);
+    // strftime の結果はロケール依存だが, デフォルトロケールは C 固定のはずなので, 大丈夫なんじゃないの.
+    char buf[1000];
+    size_t n = strftime(buf, sizeof buf, "%a, %d %b %Y %H:%M:%S %Z", &tm);
+    return byte_string(buf, buf + n);
 }
 
 HTTP::byte_string ParserHelper::decode_pct_encoded(const byte_string &str, const HTTP::CharFilter &exclude) {

--- a/src/communication/ParserHelper.hpp
+++ b/src/communication/ParserHelper.hpp
@@ -78,7 +78,10 @@ unsigned int quality_to_u(HTTP::light_string &quality);
 light_string extract_quoted_or_token(const light_string &str);
 
 // 与えられた文字列が HTTP-dateとして解釈可能なら, epoch に変換して返す.
-std::pair<bool, t_time_epoch_ms> str_to_http_date(const light_string &str);
+std::pair<bool, t_time_epoch_ms> http_date_to_time(const light_string &str);
+
+// 与えられた時刻を HTTP-date 形式(IMF-fixdate)の文字列として出力する
+byte_string time_to_http_date(t_time_epoch_ms t);
 
 // パーセントエンコードされた文字列をデコードする
 // ただしエンコード後の文字が`exclude`に含まれる場合はデコードしない

--- a/src/communication/RequestHTTP.cpp
+++ b/src/communication/RequestHTTP.cpp
@@ -473,6 +473,7 @@ minor_error RequestHTTP::extract_control_headers() {
     me = erroneous(me, this->rp.upgrade.determine(header_holder));
     me = erroneous(me, this->rp.via.determine(header_holder));
     me = erroneous(me, this->rp.date.determine(header_holder));
+    me = erroneous(me, this->rp.if_modified_since.determine(header_holder));
     me = erroneous(me, this->rp.cookie.determine(header_holder));
     VOUT(me);
     return me;
@@ -686,6 +687,10 @@ const HTTP::CH::ContentType &RequestHTTP::get_content_type_item() const {
 
 const HTTP::CH::ContentDisposition &RequestHTTP::get_content_disposition_item() const {
     return this->rp.content_disposition;
+}
+
+const HTTP::CH::IfModifiedSince &RequestHTTP::get_if_modified_since() const {
+    return this->rp.if_modified_since;
 }
 
 RequestHTTP::byte_string RequestHTTP::get_body() const {

--- a/src/communication/RequestHTTP.hpp
+++ b/src/communication/RequestHTTP.hpp
@@ -58,10 +58,18 @@ public:
     virtual byte_string get_body() const                                             = 0;
 };
 
+class ICacheInfoProvider {
+public:
+    typedef HTTP::byte_string byte_string;
+    virtual ~ICacheInfoProvider() {}
+
+    virtual const HTTP::CH::IfModifiedSince &get_if_modified_since() const = 0;
+};
+
 // [HTTPリクエストクラス]
 // [責務]
 // - 順次供給されるバイト列をHTTPリクエストとして解釈すること
-class RequestHTTP : public ICGIConfigurationProvider, public IContentProvider {
+class RequestHTTP : public ICGIConfigurationProvider, public IContentProvider, public ICacheInfoProvider {
 public:
     enum t_parse_progress {
         PP_UNREACHED,
@@ -143,6 +151,7 @@ public:
         HTTP::CH::Upgrade upgrade;
         HTTP::CH::Via via;
         HTTP::CH::Date date;
+        HTTP::CH::IfModifiedSince if_modified_since;
         HTTP::CH::Cookie cookie;
 
         // いろいろ抽出関数群
@@ -240,6 +249,7 @@ public:
     HTTP::byte_string get_content_type() const;
     const HTTP::CH::ContentType &get_content_type_item() const;
     const HTTP::CH::ContentDisposition &get_content_disposition_item() const;
+    const HTTP::CH::IfModifiedSince &get_if_modified_since() const;
 
     // 受信したデータから本文を抽出して返す
     byte_string get_body() const;

--- a/src/communication/ResponseHTTP.cpp
+++ b/src/communication/ResponseHTTP.cpp
@@ -1,4 +1,5 @@
 #include "ResponseHTTP.hpp"
+#include "ControlHeaderHTTP.hpp"
 #include <unistd.h>
 
 ResponseHTTP::ResponseHTTP(HTTP::t_version version,
@@ -14,9 +15,11 @@ ResponseHTTP::ResponseHTTP(HTTP::t_version version,
     , should_close_(should_close) {
     if (headers != NULL) {
         for (header_list_type::const_iterator it = headers->begin(); it != headers->end(); ++it) {
-            DXOUT(it->first << " - " << it->second);
             feed_header(it->first, it->second);
         }
+    }
+    if (header_dict.find(HeaderHTTP::date) == header_dict.end()) {
+        feed_header(HeaderHTTP::date, HTTP::CH::Date::now().serialize());
     }
     lifetime.activate();
 }

--- a/src/communication/RoundTrip.cpp
+++ b/src/communication/RoundTrip.cpp
@@ -80,7 +80,7 @@ IOriginator *RoundTrip::make_originator(const RequestMatchingResult &result, con
         default:
             break;
     }
-    return new FileReader(result, cacher_);
+    return new FileReader(result, cacher_, &request);
 }
 
 void RoundTrip::route(Connection &connection) {

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -4,11 +4,23 @@
 #include <unistd.h>
 #define READ_SIZE 1048576
 
-FileReader::FileReader(const RequestMatchingResult &match_result, FileCacher &cacher)
-    : file_path_(HTTP::restrfy(match_result.path_local)), originated_(false), cacher_(cacher), last_modified(0) {}
+FileReader::FileReader(const RequestMatchingResult &match_result,
+                       FileCacher &cacher,
+                       const ICacheInfoProvider *info_provider)
+    : file_path_(HTTP::restrfy(match_result.path_local))
+    , originated_(false)
+    , cacher_(cacher)
+    , last_modified(0)
+    , cache_info_provider(info_provider)
+    , is_not_modified(false) {}
 
 FileReader::FileReader(const char_string &path, FileCacher &cacher)
-    : file_path_(path), originated_(false), cacher_(cacher) {}
+    : file_path_(path)
+    , originated_(false)
+    , cacher_(cacher)
+    , last_modified(0)
+    , cache_info_provider(NULL)
+    , is_not_modified(false) {}
 
 FileReader::~FileReader() {}
 
@@ -45,6 +57,16 @@ minor_error FileReader::read_from_file() {
         time_t lut = file::get_last_update_time(file_path_);
         if (lut > 0) {
             last_modified = lut * 1000;
+
+            if (cache_info_provider != NULL) {
+                t_time_epoch_ms if_modified_since = cache_info_provider->get_if_modified_since().value;
+                if (if_modified_since > 0 && if_modified_since >= last_modified) {
+                    // 更新なし!!
+                    response_data.inject(NULL, 0, true);
+                    is_not_modified = true;
+                    return minor_error::ok();
+                }
+            }
         } else {
             last_modified = 0;
         }
@@ -171,16 +193,18 @@ HTTP::byte_string FileReader::infer_content_type() const {
 ResponseHTTP::header_list_type
 FileReader::determine_response_headers(const IResponseDataConsumer::t_sending_mode sm) const {
     ResponseHTTP::header_list_type headers;
-    switch (sm) {
-        case ResponseDataList::SM_CHUNKED:
-            headers.push_back(std::make_pair(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked")));
-            break;
-        case ResponseDataList::SM_NOT_CHUNKED:
-            headers.push_back(
-                std::make_pair(HeaderHTTP::content_length, ParserHelper::utos(response_data.current_total_size(), 10)));
-            break;
-        default:
-            break;
+    if (!is_not_modified) {
+        switch (sm) {
+            case ResponseDataList::SM_CHUNKED:
+                headers.push_back(std::make_pair(HeaderHTTP::transfer_encoding, HTTP::strfy("chunked")));
+                break;
+            case ResponseDataList::SM_NOT_CHUNKED:
+                headers.push_back(std::make_pair(HeaderHTTP::content_length,
+                                                 ParserHelper::utos(response_data.current_total_size(), 10)));
+                break;
+            default:
+                break;
+        }
     }
     // Content-Type: の推測
     headers.push_back(std::make_pair(HeaderHTTP::content_type, infer_content_type()));
@@ -194,8 +218,9 @@ FileReader::determine_response_headers(const IResponseDataConsumer::t_sending_mo
 ResponseHTTP *FileReader::respond(const RequestHTTP *request, bool should_close) {
     const IResponseDataConsumer::t_sending_mode sm = response_data.determine_sending_mode();
     ResponseHTTP::header_list_type headers         = determine_response_headers(sm);
+    const HTTP::t_status status_code               = is_not_modified ? HTTP::STATUS_NOT_MODIFIED : HTTP::STATUS_OK;
     ResponseHTTP *res
-        = new ResponseHTTP(request->get_http_version(), HTTP::STATUS_OK, &headers, &response_data, should_close);
+        = new ResponseHTTP(request->get_http_version(), status_code, &headers, &response_data, should_close);
     res->start();
     return res;
 }

--- a/src/originator/FileReader.hpp
+++ b/src/originator/FileReader.hpp
@@ -20,6 +20,8 @@ protected:
     ResponseDataList response_data;
     FileCacher &cacher_;
     t_time_epoch_ms last_modified;
+    const ICacheInfoProvider *cache_info_provider;
+    bool is_not_modified;
 
     // ファイルからデータを読み出し, response_data に入れる.
     minor_error read_from_file();
@@ -30,7 +32,7 @@ protected:
     ResponseHTTP::header_list_type determine_response_headers(const IResponseDataConsumer::t_sending_mode sm) const;
 
 public:
-    FileReader(const RequestMatchingResult &match_result, FileCacher &cacher);
+    FileReader(const RequestMatchingResult &match_result, FileCacher &cacher, const ICacheInfoProvider *info_provider);
     FileReader(const char_string &path, FileCacher &cacher);
     ~FileReader();
 

--- a/src/originator/FileReader.hpp
+++ b/src/originator/FileReader.hpp
@@ -19,8 +19,9 @@ protected:
     bool originated_;
     ResponseDataList response_data;
     FileCacher &cacher_;
+    t_time_epoch_ms last_modified;
 
-    // ファイルからデータを読み出しておく
+    // ファイルからデータを読み出し, response_data に入れる.
     minor_error read_from_file();
 
     // キャッシュデータを読み込む

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -109,31 +109,31 @@ TEST(parser_helper_str_to_u, is_minus_1) {
 
 // [extract_quoted_or_token]
 
-// [str_to_http_date]
+// [http_date_to_time]
 
 TEST(parser_helper_str_to_http_date, imf_fixdate_ok) {
     const HTTP::byte_string str          = HTTP::strfy("Sun, 06 Nov 1994 08:49:37 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
 }
 
 TEST(parser_helper_str_to_http_date, imf_fixdate_ok_unixtime_origin) {
     const HTTP::byte_string str          = HTTP::strfy("Sun, 01 Jan 1970 00:00:00 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(0, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, imf_fixdate_ok_unixtime_origin_1) {
     const HTTP::byte_string str          = HTTP::strfy("Sun, 01 Jan 1970 00:00:01 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1000, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, imf_fixdate_ok_unixtime_now) {
     const HTTP::byte_string str          = HTTP::strfy("Wed, 10 Aug 2022 02:09:46 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1660097386000, res.second);
 }
@@ -160,34 +160,34 @@ TEST(parser_helper_str_to_http_date, imf_fixdate_ko) {
                           NULL};
     for (int i = 0; strs[i]; ++i) {
         const HTTP::byte_string str          = HTTP::strfy(strs[i]);
-        std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+        std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
         EXPECT_FALSE(res.first);
     }
 }
 
 TEST(parser_helper_str_to_http_date, asctime_ok1) {
     const HTTP::byte_string str          = HTTP::strfy("Sun Nov  6 08:49:37 1994");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
 }
 
 TEST(parser_helper_str_to_http_date, asctime_ok_unixtime_origin) {
     const HTTP::byte_string str          = HTTP::strfy("Sun Jan  1 00:00:00 1970");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(0, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, asctime_ok_unixtime_origin_1) {
     const HTTP::byte_string str          = HTTP::strfy("Sun Jan  1 00:00:01 1970");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1000, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, asctime_ok_unixtime_now) {
     const HTTP::byte_string str          = HTTP::strfy("Wed Aug 10 02:09:46 2022");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1660097386000, res.second);
 }
@@ -196,34 +196,34 @@ TEST(parser_helper_str_to_http_date, asctime_ko) {
     const char *strs[] = {"Sun Nov 006 08:49:37 1994", "Sun Nov  6 08:49:37 1994 GMT", NULL};
     for (int i = 0; strs[i]; ++i) {
         const HTTP::byte_string str          = HTTP::strfy(strs[i]);
-        std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+        std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
         EXPECT_FALSE(res.first);
     }
 }
 
 TEST(parser_helper_str_to_http_date, rfc850_date_ok1) {
     const HTTP::byte_string str          = HTTP::strfy("Sunday, 06-Nov-94 08:49:37 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
 }
 
 TEST(parser_helper_str_to_http_date, rfc850_date_ok_unixtime_origin) {
     const HTTP::byte_string str          = HTTP::strfy("Sunday, 01-Jan-70 00:00:00 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(0, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, rfc850_date_ok_unixtime_origin_1) {
     const HTTP::byte_string str          = HTTP::strfy("Sunday, 01-Jan-70 00:00:01 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1000, res.second);
 }
 
 TEST(parser_helper_str_to_http_date, rfc850_date_ok_unixtime_now) {
     const HTTP::byte_string str          = HTTP::strfy("Wednesday, 10-Aug-22 02:09:46 GMT");
-    std::pair<bool, t_time_epoch_ms> res = ParserHelper::str_to_http_date(str);
+    std::pair<bool, t_time_epoch_ms> res = ParserHelper::http_date_to_time(str);
     EXPECT_TRUE(res.first);
     EXPECT_EQ(1660097386000, res.second);
 }


### PR DESCRIPTION
日時系ヘッダをいくつかサポート。

- `Date:`(レスポンス)
- `Last-Modified:`(レスポンス)
- `If-Modified-Since:`(リクエスト)

## `Date`

レスポンスの生成時刻。

## `Last-Modified:`

リクエスト対象の最終更新時刻。

## `If-Modified-Since:`

「リクエスト対象の最終更新時刻」が存在しないか、「このヘッダの値の時刻」よりも新しい場合は、通常通りの処理を行う。
そうでない場合は「リクエスト対象の最新版がクライアント側に既に存在する」とし、本文なしの304応答を返す。
→ ファイル本体を転送しないので、最終更新時刻の取得コストを考慮しても、パフォーマンスの向上が期待できる。
