### PR TITLE
FD最大数を超えてopenしようとした場合に403ではなく503を出す

### DIFF
--- a/src/originator/AutoIndexer.cpp
+++ b/src/originator/AutoIndexer.cpp
@@ -128,6 +128,9 @@ void AutoIndexer::scan_from_directory() {
                 throw http_error("file not found", HTTP::STATUS_NOT_FOUND);
             case EACCES:
                 throw http_error("permission denied", HTTP::STATUS_FORBIDDEN);
+            case EMFILE:
+            case ENFILE:
+                throw http_error("exceeding fd limits", HTTP::STATUS_SERVICE_UNAVAILABLE);
             default:
                 VOUT(errno);
                 throw http_error("can't open", HTTP::STATUS_FORBIDDEN);

--- a/src/originator/FilePoster.cpp
+++ b/src/originator/FilePoster.cpp
@@ -180,6 +180,9 @@ void FilePoster::write_file(const FileEntry &file) const {
         switch (errno) {
             case EACCES:
                 throw http_error("permission denied", HTTP::STATUS_FORBIDDEN);
+            case EMFILE:
+            case ENFILE:
+                throw http_error("exceeding fd limits", HTTP::STATUS_SERVICE_UNAVAILABLE);
             default:
                 QVOUT(strerror(errno));
                 throw http_error("can't open", HTTP::STATUS_FORBIDDEN);

--- a/src/originator/FileReader.cpp
+++ b/src/originator/FileReader.cpp
@@ -84,6 +84,9 @@ minor_error FileReader::read_from_file() {
                 return minor_error::make("file not found", HTTP::STATUS_NOT_FOUND);
             case EACCES:
                 return minor_error::make("permission denied", HTTP::STATUS_FORBIDDEN);
+            case EMFILE:
+            case ENFILE:
+                return minor_error::make("exceeding fd limits", HTTP::STATUS_SERVICE_UNAVAILABLE);
             default:
                 VOUT(errno);
                 return minor_error::make("can't open", HTTP::STATUS_FORBIDDEN);

--- a/src/originator/FileWriter.cpp
+++ b/src/originator/FileWriter.cpp
@@ -27,6 +27,9 @@ void FileWriter::write_to_file() {
         switch (errno) {
             case EACCES:
                 throw http_error("permission denied", HTTP::STATUS_FORBIDDEN);
+            case EMFILE:
+            case ENFILE:
+                throw http_error("exceeding fd limits", HTTP::STATUS_SERVICE_UNAVAILABLE);
             default:
                 VOUT(errno);
                 throw http_error("can't open", HTTP::STATUS_FORBIDDEN);


### PR DESCRIPTION
タイトルの通り。
`locust`などでテストできる。