### PR TITLE
fix_to_compile_on_Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(GTEST_LIB): $(GOOGLE_TEST)
 	rm -rf gtest-all.o  gtest_main.o
 
 $(TESTER): $(OBJ_DIRS) $(DPS_DIRS) $(OBJS) $(GTEST_LIB) $(TEST_CASE_OBJ_DIRS) $(TEST_CASE_DPS_DIRS) $(TEST_CASE_OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $(GTEST_LIB)  $(OBJS) $(TEST_CASE_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(GTEST_LIB) -lpthread $(OBJS) $(TEST_CASE_OBJS)
 
 .PHONY: unit_test
 unit_test:$(TESTER)

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -1,7 +1,7 @@
 #include "../../src/communication/ParserHelper.hpp"
 #include "gtest/gtest.h"
-#include <vector>
 #include <climits>
+#include <vector>
 
 // [find_crlf]
 

--- a/test_case/parser_helper.cpp
+++ b/test_case/parser_helper.cpp
@@ -1,6 +1,7 @@
 #include "../../src/communication/ParserHelper.hpp"
 #include "gtest/gtest.h"
 #include <vector>
+#include <climits>
 
 // [find_crlf]
 


### PR DESCRIPTION
Linux上でコンパイルが通るようになったんですが、こけるテストもありました
```
[  FAILED  ] 11 tests, listed below:
[  FAILED  ] control_header_http.date_basic_ok
[  FAILED  ] control_header_http.set_cookie_basic_ok
[  FAILED  ] parser_helper_str_to_http_date.imf_fixdate_ok_unixtime_origin
[  FAILED  ] parser_helper_str_to_http_date.imf_fixdate_ok_unixtime_origin_1
[  FAILED  ] parser_helper_str_to_http_date.imf_fixdate_ok_unixtime_now
[  FAILED  ] parser_helper_str_to_http_date.asctime_ok_unixtime_origin
[  FAILED  ] parser_helper_str_to_http_date.asctime_ok_unixtime_origin_1
[  FAILED  ] parser_helper_str_to_http_date.asctime_ok_unixtime_now
[  FAILED  ] parser_helper_str_to_http_date.rfc850_date_ok_unixtime_origin
[  FAILED  ] parser_helper_str_to_http_date.rfc850_date_ok_unixtime_origin_1
[  FAILED  ] parser_helper_str_to_http_date.rfc850_date_ok_unixtime_now
```