### PR TITLE
#254 server_nameが指定できないバグ修正

### DIFF
--- a/src/router/RequestMatcher.hpp
+++ b/src/router/RequestMatcher.hpp
@@ -49,6 +49,7 @@ private:
     bool is_executable(const RequestTarget &target, const HTTP::t_method &method, const config::Config &conf) const;
     bool is_autoindex(const RequestTarget &target, const config::Config &conf) const;
     long get_client_max_body_size(const RequestTarget &target, const config::Config &conf) const;
+    HTTP::byte_string get_server_name(const config::Config &conf, const IRequestMatchingParam &rp) const;
     redirect_pair get_redirect(const RequestTarget &target, const config::Config &conf) const;
     RequestMatchingResult::status_dict_type get_status_page_dict(const RequestTarget &target,
                                                                  const config::Config &conf) const;

--- a/test_case/config/request_matcher.cpp
+++ b/test_case/config/request_matcher.cpp
@@ -350,4 +350,100 @@ http { \
         EXPECT_EQ(minor_error::make("file not found", HTTP::STATUS_NOT_FOUND), res.error);
     }
 }
+
+TEST_F(request_matcher_test, server_name) {
+    const std::string config_data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name srv1; \
+        return 200 srv1; \
+    } \
+    server { \
+        listen 80; \
+        server_name srv2; \
+        return 200 srv2; \
+    } \
+} \
+";
+
+    setup_based_on_str(config_data);
+    const config::host_port_pair &hp = std::make_pair("0.0.0.0", 80);
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv1", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv2", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv2"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv2"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "localhost", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("0.0.0.0:80"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.redirect_location);
+    }
+}
+
+TEST_F(request_matcher_test, multi_server_name) {
+    const std::string config_data = "\
+http { \
+    server { \
+        listen 80; \
+        server_name srv1 srv2; \
+        return 200 srv12; \
+    } \
+    server { \
+        listen 80; \
+        server_name srv3 srv4; \
+        return 200 srv34; \
+    } \
+} \
+";
+
+    setup_based_on_str(config_data);
+    const config::host_port_pair &hp = std::make_pair("0.0.0.0", 80);
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv1", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv12"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv2", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv2"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv12"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv3", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv3"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv34"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "srv4", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("srv4"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv34"), res.redirect_location);
+    }
+
+    {
+        TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "localhost", "80");
+        const RequestMatchingResult res = rm.request_match(configs[hp], tp);
+        EXPECT_EQ(HTTP::strfy("0.0.0.0:80"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv12"), res.redirect_location);
+    }
+}
 } // namespace


### PR DESCRIPTION
#### 概要
resolve #254

やったこと
- hostにマッチするserver_nameがある場合は、それが使われるようにした
- hostの指定がない場合は、`host:port` がhostとして扱われるようにした