### PR TITLE
#266 listenのdefault_server指定に対応

### DIFF
--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -64,16 +64,16 @@ RequestMatchingResult RequestMatcher::request_match(const std::vector<config::Co
 
 HTTP::byte_string RequestMatcher::get_server_name(const config::Config &conf, const IRequestMatchingParam &rp) const {
     const std::vector<std::string> &server_names = conf.get_server_name();
-    const HTTP::CH::Host host_data               = rp.get_host();
-    const std::string host                       = HTTP::restrfy(host_data.host);
+    if (server_names.empty()) {
+        return HTTP::strfy("");
+    }
+
+    const HTTP::CH::Host host_data = rp.get_host();
+    const std::string host         = HTTP::restrfy(host_data.host);
 
     std::vector<std::string>::const_iterator srv_name_it = std::find(server_names.begin(), server_names.end(), host);
-
     // hostが指定されていない場合は, 先頭のserver_nameを使う
     if (srv_name_it == server_names.end()) {
-        if (server_names.empty()) {
-            return HTTP::strfy("");
-        }
         return HTTP::strfy(server_names.front());
     }
     return HTTP::strfy(*srv_name_it);

--- a/src/router/RequestMatcher.cpp
+++ b/src/router/RequestMatcher.cpp
@@ -68,12 +68,13 @@ HTTP::byte_string RequestMatcher::get_server_name(const config::Config &conf, co
     const std::string host                       = HTTP::restrfy(host_data.host);
 
     std::vector<std::string>::const_iterator srv_name_it = std::find(server_names.begin(), server_names.end(), host);
+
+    // hostが指定されていない場合は, 先頭のserver_nameを使う
     if (srv_name_it == server_names.end()) {
-        std::stringstream ss;
-        ss << conf.get_port();
-        // hostが指定されていない場合は, hostnameは `host:port` の形式となる
-        const std::string res = conf.get_host() + ":" + ss.str();
-        return HTTP::strfy(res);
+        if (server_names.empty()) {
+            return HTTP::strfy("");
+        }
+        return HTTP::strfy(server_names.front());
     }
     return HTTP::strfy(*srv_name_it);
 }
@@ -246,7 +247,14 @@ config::Config RequestMatcher::get_config(const std::vector<config::Config> &con
             return *conf_it;
         }
     }
-    // 1つも該当しない場合は先頭のconfを使う
+
+    // Hostと一致するserver_nameが存在しない場合はdefault_serverの設定があるかを調べる
+    for (std::vector<config::Config>::const_iterator conf_it = configs.begin(); conf_it != configs.end(); ++conf_it) {
+        if (conf_it->get_default_server()) {
+            return *conf_it;
+        }
+    }
+    // default_serverの設定もない場合は一番上のコンテキストを使用する
     return configs.front();
 }
 

--- a/test_case/config/request_matcher.cpp
+++ b/test_case/config/request_matcher.cpp
@@ -387,7 +387,7 @@ http { \
     {
         TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "localhost", "80");
         const RequestMatchingResult res = rm.request_match(configs[hp], tp);
-        EXPECT_EQ(HTTP::strfy("0.0.0.0:80"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.server_name);
         EXPECT_EQ(HTTP::strfy("srv1"), res.redirect_location);
     }
 }
@@ -442,7 +442,7 @@ http { \
     {
         TestParam tp(HTTP::METHOD_GET, "/", HTTP::V_1_1, "localhost", "80");
         const RequestMatchingResult res = rm.request_match(configs[hp], tp);
-        EXPECT_EQ(HTTP::strfy("0.0.0.0:80"), res.server_name);
+        EXPECT_EQ(HTTP::strfy("srv1"), res.server_name);
         EXPECT_EQ(HTTP::strfy("srv12"), res.redirect_location);
     }
 }


### PR DESCRIPTION
#### 概要
resolve #266 

以下の場合にdefalult_serverを使うようにした。
- リクエストのHostの指定がない
- Hostに対応するserver_nameが定義されていない

#262 で修正した以下の件が不要だったため差し戻した。
> hostの指定がない場合は、host:port がhostとして扱われるようにした